### PR TITLE
Map connector username to DB user in ATTACH SQL

### DIFF
--- a/crates/duckdb-engine/src/plan/builders.rs
+++ b/crates/duckdb-engine/src/plan/builders.rs
@@ -3160,7 +3160,10 @@ pub(crate) fn db_attach(props: &JsonValue, extension: &str, default_port: u64, r
     if let Some(db) = string_prop(props, "database").filter(|s| !s.is_empty()) {
         parts.push(format!("{}={}", db_key, db));
     }
-    if let Some(u) = string_prop(props, "user").filter(|s| !s.is_empty()) {
+    if let Some(u) = string_prop(props, "user")
+        .or_else(|| string_prop(props, "username"))
+        .filter(|s| !s.is_empty())
+    {
         parts.push(format!("user={}", u));
     }
     if let Some(p) = string_prop(props, "password").filter(|s| !s.is_empty()) {

--- a/crates/duckdb-engine/tests/execution.rs
+++ b/crates/duckdb-engine/tests/execution.rs
@@ -908,6 +908,39 @@ fn compiled_sql_redacts_secrets() {
 }
 
 #[test]
+fn compiled_sql_maps_username_to_attach_user() {
+    // The UI writes DB login names as `username`, while DuckDB's
+    // Postgres/MySQL connection string expects `user=...`.
+    // This is pure compilation; no live database is needed.
+    use duckle_duckdb_engine::compile_pipeline_sql_opts;
+    let d = doc(
+        json!([
+            node("s", "src.postgres", json!({
+                "host": "db.example.com",
+                "port": 5432,
+                "database": "app",
+                "username": "admin",
+                "password": "sup3rs3cr3tpw",
+                "tableName": "orders"
+            })),
+        ]),
+        json!([]),
+    );
+
+    let stages = compile_pipeline_sql_opts(&d, false).expect("compile_pipeline_sql_opts");
+    let all_sql = stages
+        .iter()
+        .map(|s| s.sql.clone())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        all_sql.contains("user=admin"),
+        "expected username to be rendered as DB user in ATTACH SQL: {}",
+        all_sql
+    );
+}
+
+#[test]
 fn sink_error_mode_refuses_to_overwrite() {
     let tmp = tempfile::tempdir().unwrap();
     let csv = write_file(tmp.path(), "in.csv", "a\n1\n");


### PR DESCRIPTION
<!--
Thanks for contributing to Duckle. Keep this short; delete any section
that does not apply.
-->

## What this changes

This maps the username passed from the frontend to `user` during attach.

## Related issue

Closes #20 

## Type

- [x] Bug fix
- [ ] New feature (connector / transform / sink)
- [ ] Performance
- [ ] Docs
- [ ] Refactor / internal

## Checklist

- [x] `cargo fmt` and `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] `cargo test --workspace` passes (engine tests need `DUCKLE_DUCKDB_BIN` set - see CONTRIBUTING.md)
- [x] `npm --prefix frontend run lint` passes (if the frontend changed)
- [x] Commits are small with imperative subject lines
- [x] No code ported from incompatibly licensed sources

## Notes for reviewers

<!-- Anything that needs context: a tradeoff you made, something you are unsure about, a follow-up you are deferring. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PostgreSQL database connection handling to support multiple authentication credential naming conventions. The system now properly recognizes both credential parameter formats and correctly processes them when executing database commands, improving compatibility with different source configuration methods and ensuring consistent behavior across various credential specification formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->