### PR TITLE
Fix serve workspace context, preview palette UX, starter workspace

### DIFF
--- a/crates/duckdb-engine/src/context.rs
+++ b/crates/duckdb-engine/src/context.rs
@@ -623,6 +623,26 @@ mod tests {
     }
 
     #[test]
+    fn apply_workspace_context_substitutes_workspace_placeholder() {
+        // serve /api/run and scheduled runs load a pipeline file directly and
+        // must resolve ${workspace} the same way the headless CLI runner does.
+        let dir = tempfile::tempdir().unwrap();
+        let ws = dir.path();
+        let mut doc: crate::PipelineDoc = serde_json::from_str(
+            r#"{"nodes":[{"id":"s","position":{"x":0,"y":0},"data":{"label":"CSV","componentId":"src.csv","properties":{"path":"${workspace}/data/orders.csv"}}}],"edges":[]}"#,
+        )
+        .unwrap();
+        super::apply_workspace_context(&mut doc, ws);
+        let props = doc.nodes[0].data.properties.as_ref().unwrap();
+        let root = ws.to_string_lossy().replace('\\', "/");
+        assert_eq!(
+            props["path"],
+            serde_json::json!(format!("{}/data/orders.csv", root)),
+            "apply_workspace_context must resolve ${{workspace}} for file-loaded pipelines"
+        );
+    }
+
+    #[test]
     fn resolve_workspace_does_not_bake_datetime() {
         // Build-safety guard: resolve_workspace (also used by the `build`
         // subcommand) must NOT resolve the date/time builtins, so a built bundle

--- a/crates/duckle-runner/src/serve.rs
+++ b/crates/duckle-runner/src/serve.rs
@@ -1039,6 +1039,10 @@ fn execute_one(state: &State, file: &str, trigger: &str) -> Result<Value, String
     let env_file = state.workspace.join("secrets.env");
     crate::apply_env_pass(&mut doc, &state.workspace, &env_file)?;
     duckle_duckdb_engine::context::apply_time_builtins(&mut doc);
+    // Match the web cmd paths and headless `duckle-runner --pipeline`: resolve
+    // ${workspace}/${projectroot} and workspace-relative file paths before run,
+    // so file-loaded pipelines (manual /api/run + scheduled runs) work too.
+    duckle_duckdb_engine::context::apply_workspace_context(&mut doc, &state.workspace);
 
     let engine = DuckdbEngine::new(state.duckdb.clone());
     let result = engine.execute_pipeline_named(&doc, &id);

--- a/examples/starter-workspace/pipelines/orders_filter.pipeline.json
+++ b/examples/starter-workspace/pipelines/orders_filter.pipeline.json
@@ -1,0 +1,38 @@
+{
+  "nodes": [
+    {
+      "id": "s1",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Orders CSV",
+        "componentId": "src.csv",
+        "properties": {
+          "path": "${workspace}/data/orders.csv",
+          "hasHeader": true
+        }
+      }
+    },
+    {
+      "id": "f1",
+      "position": { "x": 200, "y": 0 },
+      "data": {
+        "label": "Paid only",
+        "componentId": "xf.filter",
+        "properties": { "predicate": "status = 'paid'" }
+      }
+    },
+    {
+      "id": "k1",
+      "position": { "x": 400, "y": 0 },
+      "data": {
+        "label": "Parquet out",
+        "componentId": "snk.parquet",
+        "properties": { "path": "${workspace}/output/paid_orders.parquet" }
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "s1", "target": "f1", "data": { "connectionType": "main" } },
+    { "id": "e2", "source": "f1", "target": "k1", "data": { "connectionType": "main" } }
+  ]
+}

--- a/examples/starter-workspace/pipelines/region_summary.pipeline.json
+++ b/examples/starter-workspace/pipelines/region_summary.pipeline.json
@@ -1,0 +1,64 @@
+{
+  "nodes": [
+    {
+      "id": "s_orders",
+      "position": { "x": 0, "y": 0 },
+      "data": {
+        "label": "Orders",
+        "componentId": "src.csv",
+        "properties": { "path": "${workspace}/data/orders.csv", "hasHeader": true }
+      }
+    },
+    {
+      "id": "s_regions",
+      "position": { "x": 0, "y": 120 },
+      "data": {
+        "label": "Regions",
+        "componentId": "src.csv",
+        "properties": { "path": "${workspace}/data/regions.csv", "hasHeader": true }
+      }
+    },
+    {
+      "id": "j1",
+      "position": { "x": 220, "y": 60 },
+      "data": {
+        "label": "Inner Join",
+        "componentId": "xf.join.inner",
+        "properties": { "leftKey": "region", "rightKey": "region" }
+      }
+    },
+    {
+      "id": "g1",
+      "position": { "x": 440, "y": 60 },
+      "data": {
+        "label": "Group By",
+        "componentId": "xf.groupby",
+        "properties": {
+          "groupKeys": ["region", "manager"],
+          "aggregations": [{ "column": "amount", "function": "sum", "alias": "total_amount" }]
+        }
+      }
+    },
+    {
+      "id": "k1",
+      "position": { "x": 660, "y": 60 },
+      "data": {
+        "label": "CSV out",
+        "componentId": "snk.csv",
+        "properties": { "path": "${workspace}/output/region_summary.csv", "hasHeader": true }
+      }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "source": "s_orders", "target": "j1", "data": { "connectionType": "main" } },
+    {
+      "id": "e2",
+      "source": "s_regions",
+      "target": "j1",
+      "targetHandle": "lookup",
+      "data": { "connectionType": "lookup" }
+    },
+    { "id": "e3", "source": "j1", "target": "g1", "data": { "connectionType": "main" } },
+    { "id": "e4", "source": "g1", "target": "k1", "data": { "connectionType": "main" } }
+  ]
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -131,7 +131,7 @@ const SAMPLE_NODES: Node<DuckleNodeData>[] = [
             componentId: 'src.csv',
             // No path yet - set one and Autodetect. The subtitle and
             // schema fill in from the real file, they aren't faked.
-            properties: { hasHeader: true },
+            properties: { path: '${workspace}/data/orders.csv', hasHeader: true },
         },
     },
     {
@@ -152,7 +152,7 @@ const SAMPLE_NODES: Node<DuckleNodeData>[] = [
         data: {
             label: 'Parquet',
             componentId: 'snk.parquet',
-            properties: {},
+            properties: { path: '${workspace}/output/paid_orders.parquet' },
         },
     },
 ];
@@ -170,6 +170,104 @@ const SAMPLE_EDGES: Edge[] = [
     {
         id: 'e2',
         source: 't1',
+        sourceHandle: 'main',
+        target: 'k1',
+        targetHandle: 'main',
+        type: 'duckle',
+        data: { connectionType: 'main' },
+    },
+];
+
+const SAMPLE_JOIN_NODES: Node<DuckleNodeData>[] = [
+    {
+        id: 's_orders',
+        type: 'source',
+        position: { x: 40, y: 80 },
+        data: {
+            label: 'Orders',
+            componentId: 'src.csv',
+            properties: { path: '${workspace}/data/orders.csv', hasHeader: true },
+        },
+    },
+    {
+        id: 's_regions',
+        type: 'source',
+        position: { x: 40, y: 220 },
+        data: {
+            label: 'Regions',
+            componentId: 'src.csv',
+            properties: { path: '${workspace}/data/regions.csv', hasHeader: true },
+        },
+    },
+    {
+        id: 'j1',
+        type: 'transform',
+        position: { x: 320, y: 150 },
+        data: {
+            label: 'Inner Join',
+            componentId: 'xf.join.inner',
+            properties: { leftKey: 'region', rightKey: 'region' },
+        },
+    },
+    {
+        id: 'g1',
+        type: 'transform',
+        position: { x: 560, y: 150 },
+        data: {
+            label: 'Group By',
+            componentId: 'xf.groupby',
+            properties: {
+                groupKeys: ['region', 'manager'],
+                aggregations: [{ column: 'amount', function: 'sum', alias: 'total_amount' }],
+            },
+        },
+    },
+    {
+        id: 'k1',
+        type: 'sink',
+        position: { x: 800, y: 150 },
+        data: {
+            label: 'CSV',
+            componentId: 'snk.csv',
+            properties: {
+                path: '${workspace}/output/region_summary.csv',
+                hasHeader: true,
+            },
+        },
+    },
+];
+
+const SAMPLE_JOIN_EDGES: Edge[] = [
+    {
+        id: 'e1',
+        source: 's_orders',
+        sourceHandle: 'main',
+        target: 'j1',
+        targetHandle: 'main',
+        type: 'duckle',
+        data: { connectionType: 'main' },
+    },
+    {
+        id: 'e2',
+        source: 's_regions',
+        sourceHandle: 'main',
+        target: 'j1',
+        targetHandle: 'lookup',
+        type: 'duckle',
+        data: { connectionType: 'lookup' },
+    },
+    {
+        id: 'e3',
+        source: 'j1',
+        sourceHandle: 'main',
+        target: 'g1',
+        targetHandle: 'main',
+        type: 'duckle',
+        data: { connectionType: 'main' },
+    },
+    {
+        id: 'e4',
+        source: 'g1',
         sourceHandle: 'main',
         target: 'k1',
         targetHandle: 'main',
@@ -217,6 +315,9 @@ function freshId(prefix: string): string {
 function seedTemplate(template: PipelineTemplate): PipelineState {
     if (template === 'sample-csv-to-parquet') {
         return { nodes: SAMPLE_NODES, edges: SAMPLE_EDGES };
+    }
+    if (template === 'sample-join-groupby') {
+        return { nodes: SAMPLE_JOIN_NODES, edges: SAMPLE_JOIN_EDGES };
     }
     return { nodes: [], edges: [] };
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -604,6 +604,15 @@ textarea:focus-visible {
     color: var(--text-3);
 }
 
+.palette-component.is-preview {
+    color: var(--text-2);
+    opacity: 0.88;
+}
+
+.palette-component.is-preview:hover {
+    opacity: 1;
+}
+
 .palette-component.is-planned:hover {
     color: var(--text-2);
 }
@@ -617,6 +626,33 @@ textarea:focus-visible {
 
 .palette-component.is-planned .palette-component-icon {
     opacity: 0.4;
+}
+
+.palette-component.is-preview .palette-component-icon {
+    opacity: 0.65;
+}
+
+.palette-badge {
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    padding: 1px 5px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    line-height: 1.3;
+}
+
+.palette-badge-preview {
+    color: var(--warning, #c9a227);
+    background: color-mix(in srgb, var(--warning, #c9a227) 18%, transparent);
+    border: 1px solid color-mix(in srgb, var(--warning, #c9a227) 35%, transparent);
+}
+
+.palette-badge-planned {
+    color: var(--text-3);
+    background: var(--surface-2, rgba(128, 128, 128, 0.12));
+    border: 1px solid var(--border, rgba(128, 128, 128, 0.2));
 }
 
 .palette-component-label {

--- a/frontend/src/workflow-ui/NewPipelineModal.tsx
+++ b/frontend/src/workflow-ui/NewPipelineModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import type { RepoItem } from '../repo-types';
 
-export type PipelineTemplate = 'empty' | 'sample-csv-to-parquet' | 'from-sql';
+export type PipelineTemplate = 'empty' | 'sample-csv-to-parquet' | 'sample-join-groupby' | 'from-sql';
 
 type Props = {
     open: boolean;
@@ -24,6 +24,12 @@ const TEMPLATES: { id: PipelineTemplate; label: string; description: string; ava
         id: 'sample-csv-to-parquet',
         label: 'Sample · CSV → Filter → Parquet',
         description: 'Pre-wired three-node pipeline to learn the editor.',
+        available: true,
+    },
+    {
+        id: 'sample-join-groupby',
+        label: 'Sample · Join + Group By',
+        description: 'Join two CSVs and aggregate — uses xf.groupby (not xf.aggregate).',
         available: true,
     },
     {

--- a/frontend/src/workflow-ui/Palette.tsx
+++ b/frontend/src/workflow-ui/Palette.tsx
@@ -219,18 +219,39 @@ export default function Palette() {
                                         {cat.groups.map(g => (
                                             <div className="palette-group" key={g.id}>
                                                 <div className="palette-group-label">{GROUP_LABEL_KEY[g.label] ? t(GROUP_LABEL_KEY[g.label]) : g.label}</div>
-                                                {g.components.map(c => (
+                                                {g.components.map(c => {
+                                                    const availClass =
+                                                        c.availability === 'planned'
+                                                            ? ' is-planned'
+                                                            : c.availability === 'preview'
+                                                              ? ' is-preview'
+                                                              : ' is-available';
+                                                    const badgeLabel =
+                                                        c.availability === 'preview'
+                                                            ? 'Preview'
+                                                            : c.availability === 'planned'
+                                                              ? 'Planned'
+                                                              : null;
+                                                    const titleParts = [
+                                                        c.summary ?? c.label,
+                                                        c.alternateHint,
+                                                        badgeLabel
+                                                            ? `(${badgeLabel} — not executable on DuckDB engine yet)`
+                                                            : null,
+                                                    ].filter(Boolean);
+                                                    return (
                                                     <div
                                                         key={c.id}
                                                         className={
-                                                            'palette-component' +
-                                                            (c.availability === 'planned'
-                                                                ? ' is-planned'
-                                                                : ' is-available')
+                                                            'palette-component' + availClass
                                                         }
-                                                        draggable
-                                                        onDragStart={e => onDragStart(e, c)}
-                                                        title={c.summary ?? c.label}
+                                                        draggable={c.availability === 'available'}
+                                                        onDragStart={
+                                                            c.availability === 'available'
+                                                                ? e => onDragStart(e, c)
+                                                                : undefined
+                                                        }
+                                                        title={titleParts.join(' · ')}
                                                     >
                                                         <ComponentIcon
                                                             componentId={c.id}
@@ -241,7 +262,16 @@ export default function Palette() {
                                                         <span className="palette-component-label">
                                                             {c.label}
                                                         </span>
-                                                        {c.availability === 'available' ? (
+                                                        {badgeLabel ? (
+                                                            <span
+                                                                className={
+                                                                    'palette-badge palette-badge-' +
+                                                                    c.availability
+                                                                }
+                                                            >
+                                                                {badgeLabel}
+                                                            </span>
+                                                        ) : c.availability === 'available' ? (
                                                             <Check
                                                                 className="palette-availability palette-availability-yes"
                                                                 size={12}
@@ -250,11 +280,12 @@ export default function Palette() {
                                                         ) : (
                                                             <span
                                                                 className="palette-availability palette-availability-no"
-                                                                aria-label="planned"
+                                                                aria-label={c.availability}
                                                             />
                                                         )}
                                                     </div>
-                                                ))}
+                                                    );
+                                                })}
                                             </div>
                                         ))}
                                     </div>

--- a/frontend/src/workflow-ui/palette-data.ts
+++ b/frontend/src/workflow-ui/palette-data.ts
@@ -8,6 +8,8 @@ export type ComponentDef = {
     kind: NodeKind;
     availability: Availability;
     summary?: string;
+    /** When set, shown in the palette for preview/planned tiles. */
+    alternateHint?: string;
 };
 
 export type Group = {
@@ -24,12 +26,19 @@ export type Category = {
     groups: Group[];
 };
 
-const src = (id: string, label: string, availability: Availability, summary?: string): ComponentDef => ({
+const src = (
+    id: string,
+    label: string,
+    availability: Availability,
+    summary?: string,
+    alternateHint?: string,
+): ComponentDef => ({
     id: 'src.' + id,
     label,
     kind: 'source',
     availability,
     summary,
+    alternateHint,
 });
 
 const snk = (id: string, label: string, availability: Availability, summary?: string): ComponentDef => ({
@@ -40,12 +49,19 @@ const snk = (id: string, label: string, availability: Availability, summary?: st
     summary,
 });
 
-const xf = (id: string, label: string, availability: Availability, summary?: string): ComponentDef => ({
+const xf = (
+    id: string,
+    label: string,
+    availability: Availability,
+    summary?: string,
+    alternateHint?: string,
+): ComponentDef => ({
     id: 'xf.' + id,
     label,
     kind: 'transform',
     availability,
     summary,
+    alternateHint,
 });
 
 const ctl = (id: string, label: string, availability: Availability, summary?: string): ComponentDef => ({

--- a/scripts/seed-starter-workspace.sh
+++ b/scripts/seed-starter-workspace.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copy the starter workspace (sample CSVs + pipelines) into a target folder.
+set -euo pipefail
+
+TARGET="${1:-}"
+if [[ -z "$TARGET" ]]; then
+  echo "Usage: $0 <workspace-dir>" >&2
+  exit 2
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/examples/starter-workspace"
+
+mkdir -p "$TARGET"/{data,output,pipelines,logs}
+cp "$ROOT/samples/orders.csv" "$ROOT/samples/regions.csv" "$TARGET/data/"
+cp "$SRC/pipelines/"*.json "$TARGET/pipelines/"
+
+# Pipelines reference paths via the built-in ${workspace} placeholder, so no
+# repository.json / contexts/ are needed for the starter set.
+
+echo "Starter workspace seeded at $TARGET"
+echo "  data/orders.csv, data/regions.csv"
+echo "  pipelines/orders_filter.pipeline.json"
+echo "  pipelines/region_summary.pipeline.json"


### PR DESCRIPTION
## Summary
- Fix `${workspace}` path resolution in `duckle serve` `/api/run` and scheduled runs by calling `apply_workspace_context` in `execute_one`
- Add Preview/Planned palette badges (non-draggable) for components not yet executable
- Add Join+Group By pipeline template; use `${workspace}` in CSV sample template paths
- Ship `examples/starter-workspace` plus `scripts/seed-starter-workspace.sh` for onboarding
- Add regression test `apply_workspace_context_substitutes_workspace_placeholder`

## Test plan
- [x] `cargo test -p duckle-duckdb-engine context::tests::apply_workspace_context_substitutes_workspace_placeholder`
- [x] `npm --prefix frontend run lint`
- [ ] Headless `duckle-runner --pipeline` with `${workspace}` paths resolves correctly
- [ ] `POST /api/run` via `duckle serve` with `${workspace}` paths succeeds
- [ ] New pipeline templates appear in New Pipeline modal
- [ ] `./scripts/seed-starter-workspace.sh /tmp/test-ws` copies sample data and pipelines
- [ ] Preview/Planned components show badges and are not draggable