### PR TITLE
Add duckle run headless CLI subcommand

### DIFF
--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -1194,19 +1194,28 @@ struct WebPanel {
 
 static WEB_PANEL: std::sync::Mutex<Option<WebPanel>> = std::sync::Mutex::new(None);
 
-/// `duckle serve [args...]` - launch the web management console straight from a
-/// terminal using just the desktop binary (no separate runner download needed).
-/// Delegates to the embedded headless runner's `serve` subcommand and forwards
-/// any args (`--workspace`, `--port`, ...). Returns false when the first arg is
-/// not `serve` (normal GUI launch); on the serve path it never returns - it runs
-/// the server and exits with its status.
-pub fn run_serve_cli() -> bool {
+/// `duckle serve [...]` or `duckle run [...]` - delegate to the embedded
+/// headless runner without launching the GUI. Returns false when argv[1] is
+/// neither subcommand; on a headless path this never returns.
+pub fn run_headless_cli() -> bool {
     let mut it = std::env::args();
     let _exe = it.next();
-    if it.next().as_deref() != Some("serve") {
-        return false;
-    }
+    let (label, temp_dir, runner_subcommand) = match it.next().as_deref() {
+        Some("serve") => ("duckle serve", "duckle-serve", Some("serve")),
+        Some("run") => ("duckle run", "duckle-run", None),
+        _ => return false,
+    };
     let rest: Vec<String> = it.collect();
+    run_embedded_runner(label, temp_dir, runner_subcommand, &rest);
+}
+
+/// Stage the embedded runner to a temp dir and exec it with optional subcommand.
+fn run_embedded_runner(
+    label: &str,
+    temp_dir: &str,
+    subcommand: Option<&str>,
+    rest: &[String],
+) -> ! {
     // A GUI-subsystem binary has no console of its own; reattach to the terminal
     // that launched us so the runner's output is visible.
     #[cfg(windows)]
@@ -1217,15 +1226,15 @@ pub fn run_serve_cli() -> bool {
         AttachConsole(0xFFFF_FFFFu32); // ATTACH_PARENT_PROCESS
     }
     if EMBEDDED_RUNNER.is_empty() {
-        eprintln!("duckle serve: this build does not bundle the runner");
+        eprintln!("{label}: this build does not bundle the runner");
         std::process::exit(1);
     }
-    let dir = std::env::temp_dir().join("duckle-serve");
+    let dir = std::env::temp_dir().join(temp_dir);
     let _ = std::fs::create_dir_all(&dir);
     let suffix = if cfg!(windows) { ".exe" } else { "" };
     let runner = dir.join(format!("duckle-runner{suffix}"));
     if let Err(e) = write_if_changed(&runner, EMBEDDED_RUNNER) {
-        eprintln!("duckle serve: {e}");
+        eprintln!("{label}: {e}");
         std::process::exit(1);
     }
     #[cfg(unix)]
@@ -1233,13 +1242,16 @@ pub fn run_serve_cli() -> bool {
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(&runner, std::fs::Permissions::from_mode(0o755));
     }
-    let code = std::process::Command::new(&runner)
-        .arg("serve")
-        .args(&rest)
+    let mut cmd = std::process::Command::new(&runner);
+    if let Some(sub) = subcommand {
+        cmd.arg(sub);
+    }
+    let code = cmd
+        .args(rest)
         .status()
         .map(|s| s.code().unwrap_or(0))
         .unwrap_or_else(|e| {
-            eprintln!("duckle serve: failed to start: {e}");
+            eprintln!("{label}: failed to start: {e}");
             1
         });
     std::process::exit(code);

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -12,9 +12,9 @@ fn main() {
     if std::env::args().any(|a| a == "--self-update-run") {
         duckle_desktop_lib::self_update_run_selftest();
     }
-    // `duckle serve [...]` runs the web management console from a terminal,
-    // delegating to the embedded headless runner. Anything else is a GUI launch.
-    if duckle_desktop_lib::run_serve_cli() {
+    // `duckle serve [...]` and `duckle run [...]` delegate to the embedded
+    // headless runner. Anything else is a GUI launch.
+    if duckle_desktop_lib::run_headless_cli() {
         return;
     }
     duckle_desktop_lib::run();

--- a/docs/current/scheduler.md
+++ b/docs/current/scheduler.md
@@ -73,13 +73,21 @@ Run it:
 
 ### Headless runner (against an existing workspace)
 
-The same headless runner can also execute a single already-built pipeline JSON directly from a workspace, resolving the context the same way the app does:
+The same headless runner can also execute a single already-built pipeline JSON directly from a workspace, resolving the context the same way the app does.
+
+From a **Duckle desktop install** (no separate runner download):
+
+```bash
+duckle run --pipeline "/path/to/pipeline.json" [--workspace "/path/to/workspace"] [--duckdb "/path/to/duckdb"]
+```
+
+From a standalone **`duckle-runner`** binary (CI, servers, MCP):
 
 ```bash
 duckle-runner --pipeline "/path/to/pipeline.json" [--workspace "/path/to/workspace"] [--duckdb "/path/to/duckdb"]
 ```
 
-There is no `run` subcommand: pass the pipeline with `--pipeline` (or as a bare positional path). It exits `0` on success and non-zero on failure, and writes the same NDJSON run logs under `logs/` for Splunk / Dynatrace ingestion.
+Pass the pipeline with `--pipeline` (or as a bare positional path on `duckle-runner`). Both paths exit `0` on success and non-zero on failure, and write the same NDJSON run logs under `logs/` for Splunk / Dynatrace ingestion.
 
 ### Scheduling on the server
 


### PR DESCRIPTION
## Summary
- Add `duckle run --pipeline ...` on the desktop binary, delegating to the embedded `duckle-runner` (same flags as the standalone runner)
- Refactor `run_serve_cli` into shared `run_headless_cli()` / `run_embedded_runner()` so serve and run share staging logic
- Document `duckle run` in scheduler headless section alongside `duckle-runner`

Fixes the adoption-plan gap where CI/scripts had to run `duckle serve --help` just to extract a temp runner binary.

## Test plan
- [ ] `duckle run --help` prints duckle-runner usage (when runner is bundled)
- [ ] `duckle run --pipeline examples/starter-workspace/pipelines/orders_filter.pipeline.json --workspace examples/starter-workspace` exits 0
- [ ] `duckle serve` still works unchanged
- [ ] Normal `duckle` launch still opens GUI