### PR TITLE
feat(salesforce): add snk.salesforce sink (Tier 1: sObject Collections)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,20 +54,34 @@ There is no required-reviewer gate, so a maintainer will merge once it looks goo
 - **Integration tests** for crates that need them live under `crates/<name>/tests/`.
 - Run everything with `cargo test --workspace`.
 
-## Adding a connector
+## Adding a connector or transform
 
-1. Add a new module under `crates/connectors/src/`.
-2. Implement the `Connector` trait from `plugin-sdk`.
-3. Register the connector in `crates/connectors/src/lib.rs`.
-4. Add an integration test under `crates/connectors/tests/`.
-5. Add a corresponding node type in `frontend/src/canvas/nodes/`.
+Connectors (sources and sinks) and transforms are implemented in the
+`duckle-duckdb-engine` crate - not via a `plugin-sdk` trait. (The `plugin-sdk`,
+`crates/connectors`, and `crates/transform-engine` crates are legacy scaffolding
+and are not how components ship today.) The steps are the same for a source,
+sink, or transform:
 
-## Adding a transform
+1. Read an existing one as a template - e.g. `snk.snowflake` / `snk.clickhouse`
+   for a vendor HTTP sink, `src.mongodb` for an async-driver source.
+2. Define the spec struct in `crates/duckdb-engine/src/plan/specs.rs` and add a
+   `RuntimeSpec` variant in `crates/duckdb-engine/src/plan/mod.rs`.
+3. Add a routing OR-arm (parse the node's properties into the spec) in
+   `crates/duckdb-engine/src/plan/mod.rs`.
+4. Add the executor in `crates/duckdb-engine/src/connectors.rs` and a dispatch
+   arm in `crates/duckdb-engine/src/lib.rs`.
+5. Add a palette tile in `frontend/src/workflow-ui/palette-data.ts`, and - if the
+   node needs a custom property panel - a field manifest in
+   `frontend/src/workflow-ui/fields/manifest-synth.ts`. Regenerate the component
+   catalog: `node frontend/scripts/build-catalog.mjs` (writes
+   `crates/duckle-mcp/catalog.json`).
+6. Add an integration test in `crates/duckdb-engine/tests/execution.rs`. Use a
+   mock server for HTTP connectors; env-gate any real-network test so it skips
+   unless the relevant `DUCKLE_*` env var is set.
+7. Update the README capability table and `docs/roadmap.md`.
 
-1. Add a new module under `crates/transform-engine/src/ops/`.
-2. Implement the `Transform` trait from `plugin-sdk`.
-3. Register in the transform registry.
-4. Add a node type and properties panel in the frontend.
+See `docs/roadmap.md` ("Contributing a connector") for the same checklist
+alongside the roadmap of what is and isn't shipped.
 
 ## Legal
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 - [Capabilities matrix](#capabilities)
 - [Sources](#sources-74-available)
 - [Transforms](#transforms-126-available)
-- [Sinks](#sinks-58-available)
+- [Sinks](#sinks-59-available)
 - [Data quality](#data-quality-12-available)
 - [Custom code](#custom-code-7-available)
 - [Control flow](#control-flow-19-available)
@@ -341,7 +341,7 @@ Validators split their input: passing rows continue on the main port, failures r
 | **JavaScript UDF** | Per-row JS transform via pure-Rust `boa` interpreter. Sandboxed. Define a `transform(row)` function. |
 | **Python / Rust UDFs** | Embedded-language stages | Planned |
 
-### Sinks (58 available)
+### Sinks (59 available)
 
 | Group | Connectors | Status |
 |---|---|---|
@@ -355,6 +355,7 @@ Validators split their input: passing rows continue on the main port, failures r
 | **Object storage** | S3, GCS, Azure Blob via DuckDB `httpfs` (MinIO / R2 / B2 via endpoint) | Available |
 | **Cloud warehouses** | MotherDuck, Snowflake (PAT or JWT RS256; **upsert** + delete propagation via MERGE), BigQuery, Redshift, Databricks SQL (**upsert** + delete propagation via MERGE), Azure Synapse, **Teradata** (ODBC), **DuckDB Quack** (concurrent writers to remote DuckDB via the May 2026 protocol) | Available (Snowflake MERGE verified live against the SQL-API emulator) |
 | **HTTP APIs** | REST (POST/PUT/PATCH batched JSON-array; configurable API-key auth header name), Webhook (one POST per row), GraphQL mutations | Available |
+| **SaaS / CRM** | Salesforce (`snk.salesforce`) - sObject Collections API: **insert / update / upsert (by external Id) / delete**, ≤200 records/request, Bearer OAuth token (same auth as `src.salesforce`). Bulk API 2.0 for migration-scale loads is planned | Available |
 | **Email (SMTP)** | Per-row SMTP send via pure-Rust `lettre` + rustls. Plain text v1; HTML + attachments follow. | Available |
 | **NoSQL** | MongoDB (insert_many batched; **upsert** via replace_one on a key, plus delete propagation via delete_one), Cassandra / ScyllaDB (CQL), Elasticsearch / OpenSearch (`_bulk` NDJSON), Redis (pipelined SET) | Available |
 | **NoSQL** | DynamoDB | Planned |
@@ -548,7 +549,7 @@ A wider tour of the workflow.
 | **1. Sources** | Drag a source, point it at a file / DB / cloud URL / SaaS endpoint. Click **Autodetect schema** to read columns + a sample. | [Sources reference](#sources-74-available) |
 | **2. Transforms** | Wire transforms to source output ports. Configure in the Properties panel. **Preview** tab shows live rows; **Plan** tab shows generated SQL. | [Transforms reference](#transforms-126-available) |
 | **3. Data quality** | Drop in a validator (Not-Null, Range, Regex, Uniqueness). Passing rows continue on the main port; failures route to the **reject** port. | [Data quality reference](#data-quality-12-available) |
-| **4. Sinks** | Finish with a sink (file, DB, cloud, vector DB, message bus, email). Set write mode (overwrite, append, truncate, upsert). | [Sinks reference](#sinks-58-available) |
+| **4. Sinks** | Finish with a sink (file, DB, cloud, vector DB, message bus, email). Set write mode (overwrite, append, truncate, upsert). | [Sinks reference](#sinks-59-available) |
 | **5. Run** | Press **Run** to execute on DuckDB. Nodes light up stage by stage; **Output** + **Console** show row counts, timing, errors. Stop button kills mid-run. | [Run feedback](#orchestration-and-workspace) |
 | **6. Ask Duckie** | For anything you can describe in English, the AI assistant can sketch a pipeline. Iterate by editing the graph or asking follow-ups. | [Meet Duckie](#meet-duckie---the-local-ai-pipeline-assistant) |
 | **7. Reuse** | Save Connections, Context variables, and SQL Routines in the workspace; reference `${context.var}` in any field. Everything persists as plain files. | [Workspace and Git flow](#workspace-and-git-flow) |

--- a/crates/duckdb-engine/src/connectors.rs
+++ b/crates/duckdb-engine/src/connectors.rs
@@ -338,6 +338,148 @@ impl DuckdbEngine {
         }
     }
 
+    /// Salesforce REST write sink (Tier 1: sObject Collections API).
+    ///
+    /// Reads the upstream view as JSON, chunks rows into <=200-record groups,
+    /// and issues one request per chunk against the org's composite/sobjects
+    /// endpoint. Auth is a Bearer OAuth access token. The response is an array
+    /// of per-record `{id, success, errors}` results; failures are aggregated
+    /// and, when `fail_on_error`, surfaced as a single Err. A first-class
+    /// reject/error output stream is Tier 2 (see docs/salesforce-sink).
+    ///
+    /// Endpoints by operation:
+    ///   insert  POST   {instance}/services/data/{ver}/composite/sobjects
+    ///   update  PATCH  {instance}/services/data/{ver}/composite/sobjects
+    ///   upsert  PATCH  {instance}/services/data/{ver}/composite/sobjects/{obj}/{extIdField}
+    ///   delete  DELETE {instance}/services/data/{ver}/composite/sobjects?ids=..&allOrNone=..
+    pub(crate) fn run_salesforce_sink(
+        &self,
+        db: &Path,
+        secret_prefix: &str,
+        spec: &SalesforceSinkSpec,
+    ) -> Result<String, EngineError> {
+        let select = format!(
+            "{}SELECT * FROM {}",
+            secret_prefix,
+            plan::quote_ident(&spec.from_view)
+        );
+        let rows = self.run_rows(Some(db), &select)?;
+        if rows.is_empty() {
+            return Ok(format!("salesforce: 0 rows to {} {}", spec.operation, spec.object));
+        }
+
+        let base = format!(
+            "{}/services/data/{}/composite/sobjects",
+            spec.instance_url, spec.api_version
+        );
+        let auth_header = format!("Bearer {}", spec.access_token);
+        let all_or_none = spec.all_or_none;
+
+        // Build the (method, url, body) for one chunk of upstream rows.
+        // `records` carries the per-record `attributes.type` envelope that the
+        // Collections API requires and generic snk.rest cannot emit.
+        let build_request = |chunk: &[JsonValue]| -> Result<(String, String, Option<String>), EngineError> {
+            match spec.operation.as_str() {
+                "delete" => {
+                    // DELETE takes ids as a query param, no body.
+                    let ids: Vec<String> = chunk
+                        .iter()
+                        .map(|r| {
+                            r.get(&spec.id_field)
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string())
+                                .ok_or_else(|| EngineError::Query(format!(
+                                    "salesforce delete: row missing id field '{}'", spec.id_field
+                                )))
+                        })
+                        .collect::<Result<_, _>>()?;
+                    let url = format!("{}?ids={}&allOrNone={}", base, ids.join(","), all_or_none);
+                    Ok(("DELETE".into(), url, None))
+                }
+                op => {
+                    // insert / update / upsert share the records-array body.
+                    let records: Vec<JsonValue> = chunk
+                        .iter()
+                        .map(|row| salesforce_record_envelope(row, &spec.object))
+                        .collect();
+                    let mut body = serde_json::Map::new();
+                    body.insert("allOrNone".into(), JsonValue::Bool(all_or_none));
+                    body.insert("records".into(), JsonValue::Array(records));
+                    let body_str = serde_json::to_string(&JsonValue::Object(body))
+                        .unwrap_or_else(|_| "{}".into());
+                    let (method, url) = match op {
+                        "insert" => ("POST".to_string(), base.clone()),
+                        "update" => ("PATCH".to_string(), base.clone()),
+                        "upsert" => {
+                            let ext = spec.external_id_field.as_deref().unwrap_or_default();
+                            ("PATCH".to_string(), format!("{}/{}/{}", base, spec.object, ext))
+                        }
+                        other => return Err(EngineError::Query(format!(
+                            "salesforce: unsupported operation '{}'", other
+                        ))),
+                    };
+                    Ok((method, url, Some(body_str)))
+                }
+            }
+        };
+
+        let mut ok_count = 0_usize;
+        let mut fail_count = 0_usize;
+        let mut first_errors: Vec<String> = Vec::new();
+
+        for chunk in rows.chunks(spec.batch_size) {
+            self.check_cancelled()?;
+            let (method, url, body) = build_request(chunk)?;
+            let req = crate::tls::http_agent()
+                .request(&method, &url)
+                .set("Authorization", &auth_header)
+                .set("Content-Type", "application/json")
+                .set("Accept", "application/json");
+            let send = match body {
+                Some(b) => req.send_string(&b),
+                None => req.call(),
+            };
+            match send {
+                Ok(resp) => {
+                    let txt = resp.into_string().unwrap_or_default();
+                    let (ok, fail, errs) = parse_salesforce_results(&txt);
+                    ok_count += ok;
+                    fail_count += fail;
+                    for e in errs {
+                        if first_errors.len() < 5 {
+                            first_errors.push(e);
+                        }
+                    }
+                }
+                Err(ureq::Error::Status(code, response)) => {
+                    let b = response.into_string().unwrap_or_default();
+                    return Err(EngineError::Query(format!(
+                        "Salesforce HTTP {} from {}: {}",
+                        code,
+                        url,
+                        b.chars().take(300).collect::<String>()
+                    )));
+                }
+                Err(e) => {
+                    return Err(EngineError::Query(format!(
+                        "Salesforce HTTP transport to {}: {}", url, e
+                    )));
+                }
+            }
+        }
+
+        if fail_count > 0 && spec.fail_on_error {
+            return Err(EngineError::Query(format!(
+                "salesforce {} {}: {} succeeded, {} failed. First errors: {}",
+                spec.operation, spec.object, ok_count, fail_count, first_errors.join("; ")
+            )));
+        }
+        Ok(format!(
+            "salesforce {} {}: {} succeeded, {} failed",
+            spec.operation, spec.object, ok_count, fail_count
+        ))
+    }
+
     /// Snowflake SQL API sink. Reads the upstream view as JSON,
     /// chunks rows into spec.batch_size groups, builds one multi-row
     /// INSERT per chunk, and POSTs to /api/v2/statements with Bearer
@@ -8928,6 +9070,75 @@ fn snowflake_body_error(body: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+/// Wrap one upstream row as a Salesforce sObject Collections record: prepend
+/// the mandatory `attributes: {type: <object>}` envelope, then copy the row's
+/// fields. Null cells are kept (Salesforce treats an explicit null as a field
+/// clear on update/upsert). Nested object/array cells are passed through as-is;
+/// compound-field handling (Address, Location) is Tier 2.
+fn salesforce_record_envelope(row: &JsonValue, object: &str) -> JsonValue {
+    let mut rec = serde_json::Map::new();
+    let mut attrs = serde_json::Map::new();
+    attrs.insert("type".into(), JsonValue::String(object.to_string()));
+    rec.insert("attributes".into(), JsonValue::Object(attrs));
+    if let Some(obj) = row.as_object() {
+        for (k, v) in obj {
+            // Guard against a stray upstream "attributes" column shadowing ours.
+            if k == "attributes" {
+                continue;
+            }
+            rec.insert(k.clone(), v.clone());
+        }
+    }
+    JsonValue::Object(rec)
+}
+
+/// Parse a Salesforce composite/sobjects response body - an array of
+/// `{id, success, errors: [{statusCode, message, fields}]}` - into
+/// (success_count, failure_count, error_messages). A non-array body (e.g. an
+/// API-level error object) counts as a single failure carrying its message so
+/// the caller doesn't silently treat a broken batch as success.
+fn parse_salesforce_results(body: &str) -> (usize, usize, Vec<String>) {
+    let parsed: JsonValue = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(_) => return (0, 0, vec![format!("unparseable response: {}", tail_chars(body, 200))]),
+    };
+    let arr = match parsed.as_array() {
+        Some(a) => a,
+        None => {
+            // API-level error shape: [{message, errorCode}] is an array, so a
+            // bare object here is an unexpected/error envelope.
+            let msg = parsed
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unexpected non-array response");
+            return (0, 1, vec![msg.to_string()]);
+        }
+    };
+    let mut ok = 0_usize;
+    let mut fail = 0_usize;
+    let mut errs = Vec::new();
+    for item in arr {
+        let success = item.get("success").and_then(|s| s.as_bool()).unwrap_or(false);
+        if success {
+            ok += 1;
+        } else {
+            fail += 1;
+            let msg = item
+                .get("errors")
+                .and_then(|e| e.as_array())
+                .and_then(|a| a.first())
+                .map(|e| {
+                    let code = e.get("statusCode").and_then(|c| c.as_str()).unwrap_or("");
+                    let m = e.get("message").and_then(|m| m.as_str()).unwrap_or("");
+                    format!("{}: {}", code, m)
+                })
+                .unwrap_or_else(|| "unknown error".into());
+            errs.push(msg);
+        }
+    }
+    (ok, fail, errs)
 }
 
 /// Build the SELECT expression that casts a Snowflake SQL-API cell (always a

--- a/crates/duckdb-engine/src/lib.rs
+++ b/crates/duckdb-engine/src/lib.rs
@@ -59,7 +59,8 @@ use plan::{
     PubSubSourceSpec, QdrantSourceSpec, QvdSinkSpec, QvdSourceSpec, RabbitSinkSpec,
     RabbitSourceSpec, RedisSinkSpec,
     RedisSourceSpec, RestPagination, RestResponseFormat, RestSourceSpec, RuntimeSpec, ShellSpec,
-    SftpSinkSpec, SftpSourceSpec, SnowflakeAuth, SnowflakeSinkSpec, SnowflakeSourceSpec,
+    SalesforceSinkSpec, SftpSinkSpec, SftpSourceSpec, SnowflakeAuth, SnowflakeSinkSpec,
+    SnowflakeSourceSpec,
     SqlServerSinkSpec,
     SqlServerSourceSpec, WasmSpec, WeaviateSourceSpec, WebhookSourceSpec, WebhookSpec, XmlSinkSpec,
     XmlSourceSpec,
@@ -1365,6 +1366,9 @@ impl DuckdbEngine {
                     }
                     Some(RuntimeSpec::DatabricksSink(spec)) => {
                         self.run_databricks_sink(&db_path, &secret_prefix, spec)
+                    }
+                    Some(RuntimeSpec::SalesforceSink(spec)) => {
+                        self.run_salesforce_sink(&db_path, &secret_prefix, spec)
                     }
                     // Snowflake / Databricks sources: POST SELECT, parse the
                     // response, materialize as node_id via read_json_auto.

--- a/crates/duckdb-engine/src/plan/mod.rs
+++ b/crates/duckdb-engine/src/plan/mod.rs
@@ -127,6 +127,9 @@ pub enum RuntimeSpec {
     Webhook(WebhookSpec),
     SnowflakeSink(SnowflakeSinkSpec),
     DatabricksSink(DatabricksSinkSpec),
+    /// snk.salesforce: write rows into a Salesforce object (Tier 1 = sObject
+    /// Collections). See SalesforceSinkSpec / docs/salesforce-sink.
+    SalesforceSink(SalesforceSinkSpec),
     SnowflakeSource(SnowflakeSourceSpec),
     DatabricksSource(DatabricksSourceSpec),
     RestSource(RestSourceSpec),
@@ -961,6 +964,7 @@ fn build_stage(
     let mut ducklake_cdc: Option<DuckLakeCdcSpec> = None;
     let mut snowflake_sink: Option<SnowflakeSinkSpec> = None;
     let mut databricks_sink: Option<DatabricksSinkSpec> = None;
+    let mut salesforce_sink: Option<SalesforceSinkSpec> = None;
     let mut snowflake_source: Option<SnowflakeSourceSpec> = None;
     let mut databricks_source: Option<DatabricksSourceSpec> = None;
     let mut rest_source: Option<RestSourceSpec> = None;
@@ -1637,6 +1641,81 @@ fn build_stage(
             upsert_keys: upsert_keys_from(&props),
             delete_column: delete_column_from(&props),
             delete_value: delete_value_from(&props),
+        });
+        (String::new(), StageKind::Sink, Some(from_view.to_string()))
+    } else if component_id == "snk.salesforce" {
+        // Salesforce REST write sink (Tier 1: sObject Collections, <=200/req).
+        // Auth: Bearer OAuth access token, same token as src.salesforce.
+        // instance_url doubles as the endpoint base tests point at a mock.
+        let from_view = inputs.main().ok_or_else(|| missing_input(node, "main"))?;
+        let instance_url = string_prop(&props, "instanceUrl")
+            .map(|s| s.trim_end_matches('/').to_string())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| EngineError::Config(format!(
+                "{}: instanceUrl required (e.g. https://acme.my.salesforce.com)",
+                component_id
+            )))?;
+        let access_token = string_prop(&props, "accessToken")
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| EngineError::Config(format!(
+                "{}: accessToken required (Bearer OAuth token; use ${{ENV:SF_TOKEN}})",
+                component_id
+            )))?;
+        let object = string_prop(&props, "object")
+            .or_else(|| string_prop(&props, "sobject"))
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| EngineError::Config(format!(
+                "{}: object required (e.g. Account)", component_id
+            )))?;
+        let operation = string_prop(&props, "operation")
+            .unwrap_or_else(|| "insert".into())
+            .to_lowercase();
+        if !matches!(operation.as_str(), "insert" | "update" | "upsert" | "delete") {
+            return Err(EngineError::Config(format!(
+                "{}: operation must be insert|update|upsert|delete (got '{}')",
+                component_id, operation
+            )));
+        }
+        let external_id_field = string_prop(&props, "externalIdField")
+            .filter(|s| !s.is_empty());
+        if operation == "upsert" && external_id_field.is_none() {
+            return Err(EngineError::Config(format!(
+                "{}: externalIdField required when operation = upsert", component_id
+            )));
+        }
+        // Tier 2: Bulk API 2.0 is not wired yet - reject with a clear message
+        // rather than silently falling back to Collections at scale.
+        let api = match string_prop(&props, "api").unwrap_or_else(|| "collections".into()).as_str() {
+            "bulk" => return Err(EngineError::Config(format!(
+                "{}: api='bulk' (Bulk API 2.0) is not yet implemented; use 'collections' \
+                 (<=200 records/request). See docs/salesforce-sink/IMPLEMENTATION.md.",
+                component_id
+            ))),
+            _ => SalesforceWriteApi::Collections,
+        };
+        salesforce_sink = Some(SalesforceSinkSpec {
+            from_view: from_view.to_string(),
+            instance_url,
+            api_version: string_prop(&props, "apiVersion")
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "v60.0".into()),
+            access_token,
+            object,
+            operation,
+            external_id_field,
+            id_field: string_prop(&props, "idField")
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "Id".into()),
+            // Salesforce hard-caps sObject Collections at 200.
+            batch_size: props
+                .get("batchSize")
+                .and_then(|v| v.as_u64())
+                .filter(|n| *n > 0)
+                .unwrap_or(200)
+                .min(200) as usize,
+            all_or_none: props.get("allOrNone").and_then(|v| v.as_bool()).unwrap_or(false),
+            fail_on_error: props.get("failOnError").and_then(|v| v.as_bool()).unwrap_or(true),
+            api,
         });
         (String::new(), StageKind::Sink, Some(from_view.to_string()))
     } else if component_id == "snk.elastic" || component_id == "snk.opensearch" {
@@ -4186,6 +4265,7 @@ fn build_stage(
         .or_else(|| remote_exec.map(RuntimeSpec::RemoteExec))
         .or_else(|| snowflake_sink.map(RuntimeSpec::SnowflakeSink))
         .or_else(|| databricks_sink.map(RuntimeSpec::DatabricksSink))
+        .or_else(|| salesforce_sink.map(RuntimeSpec::SalesforceSink))
         .or_else(|| snowflake_source.map(RuntimeSpec::SnowflakeSource))
         .or_else(|| databricks_source.map(RuntimeSpec::DatabricksSource))
         .or_else(|| rest_source.map(RuntimeSpec::RestSource))

--- a/crates/duckdb-engine/src/plan/specs.rs
+++ b/crates/duckdb-engine/src/plan/specs.rs
@@ -1379,6 +1379,61 @@ pub struct WebhookSpec {
     pub text_template: Option<String>,
 }
 
+/// Which Salesforce write API a SalesforceSinkSpec uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SalesforceWriteApi {
+    /// sObject Collections / Composite: up to 200 records per request via a
+    /// single synchronous round-trip. Tier 1 - fits the existing ureq
+    /// per-stage model. `/composite/sobjects` (insert/update/delete) and
+    /// `/composite/sobjects/{sobject}/{extIdField}` (upsert).
+    Collections,
+    /// Bulk API 2.0: async job lifecycle (create job -> upload CSV -> close ->
+    /// poll -> fetch success/failed result sets). Tier 2 - NOT yet wired; the
+    /// planner rejects it with a clear "not yet implemented" error so the
+    /// config is at least diagnosable. See docs/salesforce-sink/IMPLEMENTATION.md.
+    Bulk,
+}
+
+/// snk.salesforce: write upstream rows into a Salesforce object via the REST
+/// write APIs. Tier 1 targets the sObject Collections API (<=200 records per
+/// request). Auth is a Bearer OAuth access token, same token flow as
+/// src.salesforce; supply it via `${ENV:SF_TOKEN}` so no secret lands in the
+/// pipeline JSON. `instance_url` is the org base (e.g.
+/// https://acme.my.salesforce.com) and doubles as the endpoint override tests
+/// point at a mock server.
+#[derive(Debug, Clone)]
+pub struct SalesforceSinkSpec {
+    pub from_view: String,
+    /// Org base URL, e.g. https://acme.my.salesforce.com. No trailing slash.
+    pub instance_url: String,
+    /// REST API version segment, e.g. "v60.0".
+    pub api_version: String,
+    /// Bearer OAuth access token.
+    pub access_token: String,
+    /// sObject API name, e.g. "Account", "Contact", "MyObject__c".
+    pub object: String,
+    /// "insert" | "update" | "upsert" | "delete".
+    pub operation: String,
+    /// Required when operation == "upsert": the external-id field the upsert
+    /// keys on (e.g. "External_Id__c"). Ignored otherwise.
+    pub external_id_field: Option<String>,
+    /// For operation == "update"/"delete": the row column holding the
+    /// Salesforce record Id (default "Id").
+    pub id_field: String,
+    /// Records per request. Salesforce caps sObject Collections at 200; the
+    /// planner clamps to that.
+    pub batch_size: usize,
+    /// allOrNone flag sent to Salesforce. When true, any failing record rolls
+    /// back the whole request (Salesforce-side). When false, partial success.
+    pub all_or_none: bool,
+    /// When true, the stage errors if any record fails; when false it logs the
+    /// per-record errors and continues. A first-class reject/error output
+    /// stream is Tier 2 work (see IMPLEMENTATION.md).
+    pub fail_on_error: bool,
+    /// Which write API to use (Tier 1 = Collections).
+    pub api: SalesforceWriteApi,
+}
+
 /// snk.execsource "Execute in Source" (#115 in-database processing v1b): run a
 /// statement (typically CREATE TABLE ... AS SELECT) directly on the attached
 /// remote server via the scanner extension's passthrough (postgres_execute /

--- a/crates/duckdb-engine/tests/execution.rs
+++ b/crates/duckdb-engine/tests/execution.rs
@@ -11036,3 +11036,220 @@ fn inspect_parquet_regression_still_selects() {
         names
     );
 }
+
+// --- snk.salesforce (sObject Collections) ------------------------------------
+//
+// These drive the real executor against a mock HTTP server standing in for the
+// org (instanceUrl points at 127.0.0.1). They assert the request shape generic
+// snk.rest cannot produce - the per-record `attributes.type` envelope and the
+// `allOrNone` wrapper - plus the upsert URL and per-record error handling. The
+// live-org behaviour (insert/update/upsert/delete) is validated manually; see
+// docs/salesforce-sink/IMPLEMENTATION.md.
+
+/// Spawn a one-shot mock HTTP server that records the first request's raw bytes
+/// and replies with `resp_body` as application/json. Returns (port, rx, join).
+#[allow(clippy::type_complexity)]
+fn sf_mock_server(
+    resp_body: &'static str,
+) -> (
+    u16,
+    std::sync::mpsc::Receiver<Vec<u8>>,
+    std::thread::JoinHandle<()>,
+) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind sf mock");
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        for stream in listener.incoming().take(1) {
+            let mut stream = match stream {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_millis(250)))
+                .ok();
+            stream.set_nodelay(true).ok();
+            let mut buf = Vec::with_capacity(8192);
+            let mut chunk = [0u8; 4096];
+            for _ in 0..16 {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                    Err(_) => break,
+                }
+            }
+            let _ = tx.send(buf);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                resp_body.len(),
+                resp_body
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+            let _ = stream.shutdown(std::net::Shutdown::Write);
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    });
+    (port, rx, handle)
+}
+
+#[test]
+fn snk_salesforce_insert_posts_collections_envelope() {
+    use std::time::Duration;
+    let engine = engine_or_skip!();
+    let (port, rx, handle) = sf_mock_server(
+        r#"[{"id":"001000000000001","success":true,"errors":[]},{"id":"001000000000002","success":true,"errors":[]}]"#,
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let csv = write_file(tmp.path(), "in.csv", "Name\nAcme\nGlobex\n");
+    let instance = format!("http://127.0.0.1:{}", port);
+    let r = engine.execute_pipeline(&doc(
+        json!([
+            node("s", "src.csv", json!({ "path": csv, "hasHeader": true })),
+            node(
+                "f",
+                "snk.salesforce",
+                json!({
+                    "instanceUrl": instance,
+                    "accessToken": "tok-123",
+                    "apiVersion": "v60.0",
+                    "object": "Account",
+                    "operation": "insert"
+                }),
+            ),
+        ]),
+        json!([main_edge("e", "s", "f")]),
+    ));
+    assert_eq!(r.status, "ok", "salesforce insert failed: {:?}", r.error);
+
+    let req = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("expected 1 SF request");
+    let _ = handle.join();
+    let raw = String::from_utf8_lossy(&req);
+    let line0 = raw.lines().next().unwrap_or("");
+    assert!(line0.starts_with("POST "), "expected POST, got: {}", line0);
+    assert!(
+        line0.contains("/services/data/v60.0/composite/sobjects"),
+        "endpoint path missing: {}",
+        line0
+    );
+    assert!(
+        raw.contains("Authorization: Bearer tok-123"),
+        "bearer auth header missing"
+    );
+    let body = raw.split("\r\n\r\n").nth(1).unwrap_or("");
+    let v: Value = serde_json::from_str(body).expect("body should be JSON");
+    assert_eq!(v["allOrNone"], json!(false));
+    let recs = v["records"].as_array().expect("records array");
+    assert_eq!(recs.len(), 2);
+    // The per-record type envelope is the whole point of a dedicated sink.
+    assert_eq!(recs[0]["attributes"]["type"], json!("Account"));
+    let names: Vec<&str> = recs
+        .iter()
+        .map(|r| r["Name"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        names.contains(&"Acme") && names.contains(&"Globex"),
+        "row data missing: {:?}",
+        names
+    );
+}
+
+#[test]
+fn snk_salesforce_upsert_targets_external_id_url() {
+    use std::time::Duration;
+    let engine = engine_or_skip!();
+    let (port, rx, handle) = sf_mock_server(
+        r#"[{"id":"001000000000001","success":true,"errors":[]},{"id":"001000000000002","success":true,"errors":[]}]"#,
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let csv = write_file(
+        tmp.path(),
+        "in.csv",
+        "External_ID__c,Name\nDKL-1,Acme\nDKL-2,Globex\n",
+    );
+    let instance = format!("http://127.0.0.1:{}", port);
+    let r = engine.execute_pipeline(&doc(
+        json!([
+            node("s", "src.csv", json!({ "path": csv, "hasHeader": true })),
+            node(
+                "f",
+                "snk.salesforce",
+                json!({
+                    "instanceUrl": instance,
+                    "accessToken": "tok-123",
+                    "apiVersion": "v60.0",
+                    "object": "Account",
+                    "operation": "upsert",
+                    "externalIdField": "External_ID__c"
+                }),
+            ),
+        ]),
+        json!([main_edge("e", "s", "f")]),
+    ));
+    assert_eq!(r.status, "ok", "salesforce upsert failed: {:?}", r.error);
+
+    let req = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("expected 1 SF request");
+    let _ = handle.join();
+    let raw = String::from_utf8_lossy(&req);
+    let line0 = raw.lines().next().unwrap_or("");
+    // Upsert routes through PATCH .../composite/sobjects/{object}/{extIdField}.
+    assert!(line0.starts_with("PATCH "), "expected PATCH, got: {}", line0);
+    assert!(
+        line0.contains("/services/data/v60.0/composite/sobjects/Account/External_ID__c"),
+        "upsert URL missing external-id path: {}",
+        line0
+    );
+}
+
+#[test]
+fn snk_salesforce_record_error_fails_run() {
+    use std::time::Duration;
+    let engine = engine_or_skip!();
+    // One record fails; with failOnError (default true) the run must error.
+    let (port, rx, handle) = sf_mock_server(
+        r#"[{"success":false,"errors":[{"statusCode":"REQUIRED_FIELD_MISSING","message":"Required fields are missing: [Name]"}]},{"id":"001000000000002","success":true,"errors":[]}]"#,
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let csv = write_file(tmp.path(), "in.csv", "Name\nAcme\nGlobex\n");
+    let instance = format!("http://127.0.0.1:{}", port);
+    let r = engine.execute_pipeline(&doc(
+        json!([
+            node("s", "src.csv", json!({ "path": csv, "hasHeader": true })),
+            node(
+                "f",
+                "snk.salesforce",
+                json!({
+                    "instanceUrl": instance,
+                    "accessToken": "tok-123",
+                    "object": "Account",
+                    "operation": "insert"
+                }),
+            ),
+        ]),
+        json!([main_edge("e", "s", "f")]),
+    ));
+    let _ = rx.recv_timeout(Duration::from_secs(5));
+    let _ = handle.join();
+    assert_eq!(
+        r.status, "error",
+        "a failing record must fail the run when failOnError"
+    );
+    let err = r.error.unwrap_or_default();
+    assert!(
+        err.contains("REQUIRED_FIELD_MISSING"),
+        "error should surface the Salesforce statusCode, got: {}",
+        err
+    );
+}

--- a/crates/duckle-mcp/catalog.json
+++ b/crates/duckle-mcp/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "componentCount": 362,
+  "componentCount": 363,
   "components": [
     {
       "id": "src.csv",
@@ -30352,6 +30352,158 @@
                     "value": "json"
                   }
                 ]
+              }
+            ]
+          }
+        ],
+        "ports": {
+          "inputs": [
+            {
+              "id": "main",
+              "label": "main",
+              "type": "main"
+            }
+          ],
+          "outputs": []
+        }
+      }
+    },
+    {
+      "id": "snk.salesforce",
+      "label": "Salesforce",
+      "kind": "sink",
+      "availability": "available",
+      "summary": "Write rows into a Salesforce object via the REST sObject Collections API (<=200 records/request). insert / update / upsert (by external Id) / delete; Bearer OAuth token, same auth as src.salesforce. Bulk API 2.0 for migration-scale loads is planned (see docs/salesforce-sink).",
+      "ports": {
+        "inputs": [
+          {
+            "id": "main",
+            "label": "main",
+            "type": "main"
+          }
+        ],
+        "outputs": []
+      },
+      "manifest": {
+        "id": "snk.salesforce",
+        "kind": "sink",
+        "label": "Salesforce",
+        "description": "Write rows into a Salesforce object via the REST sObject Collections API (<=200 records/request). insert / update / upsert (by external Id) / delete; Bearer OAuth token, same auth as src.salesforce. Bulk API 2.0 for migration-scale loads is planned (see docs/salesforce-sink).",
+        "schemaSource": "upstream",
+        "sections": [
+          {
+            "label": "Salesforce org",
+            "fields": [
+              {
+                "key": "instanceUrl",
+                "label": "Instance URL",
+                "kind": "text",
+                "required": true,
+                "placeholder": "https://acme.my.salesforce.com",
+                "description": "Org base URL (no trailing slash)."
+              },
+              {
+                "key": "accessToken",
+                "label": "Access token (Bearer)",
+                "kind": "text",
+                "required": true,
+                "placeholder": "${ENV:SF_TOKEN}",
+                "description": "OAuth access token, same token flow as src.salesforce. Use ${ENV:...} so no secret lands in the pipeline JSON."
+              },
+              {
+                "key": "apiVersion",
+                "label": "API version",
+                "kind": "text",
+                "defaultValue": "v60.0"
+              }
+            ]
+          },
+          {
+            "label": "Destination",
+            "fields": [
+              {
+                "key": "object",
+                "label": "sObject",
+                "kind": "text",
+                "required": true,
+                "placeholder": "Account",
+                "description": "Salesforce object API name, e.g. Account, Contact, MyObject__c."
+              },
+              {
+                "key": "operation",
+                "label": "Operation",
+                "kind": "select",
+                "defaultValue": "insert",
+                "options": [
+                  {
+                    "label": "Insert",
+                    "value": "insert"
+                  },
+                  {
+                    "label": "Update (by Id)",
+                    "value": "update"
+                  },
+                  {
+                    "label": "Upsert (by external Id)",
+                    "value": "upsert"
+                  },
+                  {
+                    "label": "Delete (by Id)",
+                    "value": "delete"
+                  }
+                ]
+              },
+              {
+                "key": "externalIdField",
+                "label": "External Id field (upsert)",
+                "kind": "text",
+                "placeholder": "External_Id__c",
+                "description": "Required when Operation is Upsert."
+              },
+              {
+                "key": "idField",
+                "label": "Id column (update/delete)",
+                "kind": "text",
+                "defaultValue": "Id",
+                "description": "Upstream column holding the Salesforce record Id."
+              },
+              {
+                "key": "api",
+                "label": "Write API",
+                "kind": "select",
+                "defaultValue": "collections",
+                "options": [
+                  {
+                    "label": "sObject Collections (<=200/req)",
+                    "value": "collections"
+                  },
+                  {
+                    "label": "Bulk API 2.0 (not yet implemented)",
+                    "value": "bulk"
+                  }
+                ],
+                "description": "Collections is Tier 1. Bulk API 2.0 is planned - see docs/salesforce-sink."
+              },
+              {
+                "key": "batchSize",
+                "label": "Records per request",
+                "kind": "integer",
+                "defaultValue": 200,
+                "description": "Salesforce caps sObject Collections at 200; higher values are clamped."
+              },
+              {
+                "key": "allOrNone",
+                "label": "All-or-none",
+                "kind": "bool",
+                "defaultValue": false,
+                "description": "When on, any failing record rolls back the whole request (Salesforce-side)."
+              },
+              {
+                "key": "failOnError",
+                "label": "Fail the run on record errors",
+                "kind": "bool",
+                "defaultValue": true,
+                "description": "When off, per-record errors are logged and the stage continues (a reject output stream is planned)."
               }
             ]
           }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -183,12 +183,18 @@ The fastest path for a new connector is to:
 1. Read an existing one as a template - `snk.pinecone` (~40 lines) for a
    vendor HTTP sink, `src.mongodb` (~60 lines + a tokio block_on
    pattern) for an async-driver source.
-2. Add an OR-arm to the planner branch in `crates/duckdb-engine/src/plan.rs`.
-3. Add an executor branch in `crates/duckdb-engine/src/lib.rs`.
-4. Add a palette tile in `frontend/src/workflow-ui/palette-data.ts`.
+2. Define the spec in `crates/duckdb-engine/src/plan/specs.rs` and add a
+   `RuntimeSpec` variant + a routing OR-arm in
+   `crates/duckdb-engine/src/plan/mod.rs`.
+3. Add the executor in `crates/duckdb-engine/src/connectors.rs` and a dispatch
+   arm in `crates/duckdb-engine/src/lib.rs`.
+4. Add a palette tile in `frontend/src/workflow-ui/palette-data.ts` (plus a field
+   manifest in `frontend/src/workflow-ui/fields/manifest-synth.ts` when the node
+   needs a custom property panel), then regenerate the catalog:
+   `node frontend/scripts/build-catalog.mjs`.
 5. Add an integration test in `crates/duckdb-engine/tests/execution.rs` -
    real network tests should be `env-gated` (skip unless the relevant
-   `DUCKLE_*_URI` env var is set).
+   `DUCKLE_*` env var is set); a mock HTTP server keeps a connector test in CI.
 6. Update the README capability table and this roadmap.
 
 See `CONTRIBUTING.md` for the broader project conventions.

--- a/docs/salesforce-sink/IMPLEMENTATION.md
+++ b/docs/salesforce-sink/IMPLEMENTATION.md
@@ -81,6 +81,11 @@ Response: array of `{ "id", "success", "errors": [{statusCode, message, fields}]
 
 ## Remaining work
 
+_Items 1–4 below are complete (see Status above): the sink compiles, has passing
+integration tests, is validated end-to-end against a live org (incl. via the
+desktop UI), and the docs are updated (README Sinks table, `docs/roadmap.md`,
+CONTRIBUTING.md). Items 5–6 (Tier 2/3) remain._
+
 1. **Compile + fix** — install the Rust toolchain, `cargo build -p duckle-duckdb-engine`, resolve any signature drift (helper names, `ureq` request builder, `EngineError` variants).
 2. **Unit/integration test** — add a `TcpListener::bind("127.0.0.1:0")` mock in `crates/duckdb-engine/tests/execution.rs` (mirror the `snk.snowflake` tests ~line 1964/2316 and the mock-server sinks ~line 3446+). Point `instanceUrl` at the mock; assert the request envelope (per-record `attributes.type`, `allOrNone`), the ≤200 chunking, and that a `success:false` record fails the run when `failOnError`. Sketch:
    ```
@@ -90,9 +95,10 @@ Response: array of `{ "id", "success", "errors": [{statusCode, message, fields}]
    // then run pipeline: src.json (2 rows) -> snk.salesforce(insert) and assert "2 succeeded"
    ```
 3. **Live-org validation** — a Salesforce dev org + Connected App; run insert/update/upsert/delete against a real object; confirm error-payload shapes, field-type coercion (dates, checkboxes, references), and API-version behaviour.
-4. **Docs** — README connector table + a short usage snippet.
-5. **Tier 2 (Bulk API 2.0)** — new `RuntimeSpec` path with a poll loop; the `SalesforceWriteApi::Bulk` variant is already reserved and rejected at plan time.
-6. **Tier 3** — reject/error output stream, ID remapping, compound fields, retry/backoff.
+4. **Docs** — ✅ done: README capability table (Sinks row + count bump), `docs/roadmap.md`, and the CONTRIBUTING.md connector/transform recipe corrected.
+5. **Tier 2 — Bulk API 2.0** — new `RuntimeSpec` path with a poll loop; the `SalesforceWriteApi::Bulk` variant is already reserved and rejected at plan time.
+6. **Tier 2 — Salesforce auth Connection** — both `src.salesforce` and this sink are Bearer-token-only (no minting or refresh; the token expires ~2h). A first-class Salesforce Connection that stores Client-Credentials (key/secret) or a JWT cert and mints + refreshes the token would upgrade the source and the sink at once. Duckle already has a Connection concept (`create_connection`/`list_connections`).
+7. **Tier 3** — reject/error output stream, parent→child ID remapping, external-Id relationship resolution, compound fields (Address/Location), API-limit retry/backoff.
 
 ## Contribution checklist (per CONTRIBUTING.md)
 

--- a/docs/salesforce-sink/IMPLEMENTATION.md
+++ b/docs/salesforce-sink/IMPLEMENTATION.md
@@ -7,7 +7,7 @@ Salesforce, not just out of it.
 
 ## Status
 
-**Tier 1 (sObject Collections) — compiles; not yet tested against a live org.**
+**Tier 1 (sObject Collections) — complete: compiles, unit-tested, and validated end-to-end against a live org (including via the desktop UI).**
 
 - `cargo check -p duckle-duckdb-engine` — **passes** (rustc 1.97.0, stable-msvc).
 - `cargo clippy -p duckle-duckdb-engine` — the Salesforce code adds **zero**
@@ -35,7 +35,7 @@ Salesforce, not just out of it.
 
 | Tier | Scope | State |
 |------|-------|-------|
-| 1 | sObject Collections API (`/composite/sobjects`), ≤200 records/request: insert / update / upsert (by external Id) / delete, Bearer auth, per-record error aggregation | **scaffolded** |
+| 1 | sObject Collections API (`/composite/sobjects`), ≤200 records/request: insert / update / upsert (by external Id) / delete, Bearer auth, per-record error aggregation | **complete** (live-org + mock tests) |
 | 2 | Bulk API 2.0 (`/jobs/ingest`): create → upload CSV → close → poll → fetch success/failed result sets. Migration-scale volume. | planner rejects `api:"bulk"` with a clear message; not built |
 | 3 | Migration-grade: first-class reject/error output stream, parent→child ID remapping, external-Id relationship resolution, compound-field (Address/Location) handling, API-limit retry/backoff | not started |
 
@@ -81,24 +81,13 @@ Response: array of `{ "id", "success", "errors": [{statusCode, message, fields}]
 
 ## Remaining work
 
-_Items 1–4 below are complete (see Status above): the sink compiles, has passing
-integration tests, is validated end-to-end against a live org (incl. via the
-desktop UI), and the docs are updated (README Sinks table, `docs/roadmap.md`,
-CONTRIBUTING.md). Items 5–6 (Tier 2/3) remain._
+Tier 1 is complete (see Status) and shipped in this PR — sink implemented,
+unit-tested, validated end-to-end against a live org, and docs updated (README
+Sinks table, `docs/roadmap.md`, `CONTRIBUTING.md`). What's left is follow-up:
 
-1. **Compile + fix** — install the Rust toolchain, `cargo build -p duckle-duckdb-engine`, resolve any signature drift (helper names, `ureq` request builder, `EngineError` variants).
-2. **Unit/integration test** — add a `TcpListener::bind("127.0.0.1:0")` mock in `crates/duckdb-engine/tests/execution.rs` (mirror the `snk.snowflake` tests ~line 1964/2316 and the mock-server sinks ~line 3446+). Point `instanceUrl` at the mock; assert the request envelope (per-record `attributes.type`, `allOrNone`), the ≤200 chunking, and that a `success:false` record fails the run when `failOnError`. Sketch:
-   ```
-   // POST /services/data/v60.0/composite/sobjects
-   //   assert body.records[0].attributes.type == "Account"
-   //   respond [{ "id":"001...", "success":true, "errors":[] }]
-   // then run pipeline: src.json (2 rows) -> snk.salesforce(insert) and assert "2 succeeded"
-   ```
-3. **Live-org validation** — a Salesforce dev org + Connected App; run insert/update/upsert/delete against a real object; confirm error-payload shapes, field-type coercion (dates, checkboxes, references), and API-version behaviour.
-4. **Docs** — ✅ done: README capability table (Sinks row + count bump), `docs/roadmap.md`, and the CONTRIBUTING.md connector/transform recipe corrected.
-5. **Tier 2 — Bulk API 2.0** — new `RuntimeSpec` path with a poll loop; the `SalesforceWriteApi::Bulk` variant is already reserved and rejected at plan time.
-6. **Tier 2 — Salesforce auth Connection** — both `src.salesforce` and this sink are Bearer-token-only (no minting or refresh; the token expires ~2h). A first-class Salesforce Connection that stores Client-Credentials (key/secret) or a JWT cert and mints + refreshes the token would upgrade the source and the sink at once. Duckle already has a Connection concept (`create_connection`/`list_connections`).
-7. **Tier 3** — reject/error output stream, parent→child ID remapping, external-Id relationship resolution, compound fields (Address/Location), API-limit retry/backoff.
+1. **Tier 2 — Bulk API 2.0** — new `RuntimeSpec` path with a poll loop (create → upload CSV → close → poll → fetch success/failed results); the `SalesforceWriteApi::Bulk` variant is already reserved and rejected at plan time.
+2. **Tier 2 — Salesforce auth Connection** — both `src.salesforce` and this sink are Bearer-token-only (no minting or refresh; the token expires ~2h). A first-class Salesforce Connection that stores Client-Credentials (key/secret) or a JWT cert and mints + refreshes the token would upgrade the source and the sink at once. Duckle already has a Connection concept (`create_connection`/`list_connections`).
+3. **Tier 3** — reject/error output stream, parent→child ID remapping, external-Id relationship resolution, compound fields (Address/Location), API-limit retry/backoff.
 
 ## Contribution checklist (per CONTRIBUTING.md)
 
@@ -122,14 +111,14 @@ Linux/macOS/Windows; no required-reviewer gate):
 - [x] Written from scratch, no incompatibly-licensed code (dual MIT/Apache-2.0);
       no CLA/DCO sign-off required
 
-**Note — CONTRIBUTING.md "Adding a connector" is stale.** It says add a module
-under `crates/connectors/src/`, implement a `Connector` trait from `plugin-sdk`,
-and add a node under `frontend/src/canvas/nodes/`. None of that matches reality:
-`crates/connectors/src/` holds only `csv.rs` + `lib.rs`, and every actual sink
-(Snowflake, Databricks, ClickHouse, Mongo, Kafka, …) lives in
+**Note — this PR also corrects two stale contributor guides.** `CONTRIBUTING.md`
+previously said to add a module under `crates/connectors/src/`, implement a
+`Connector`/`Transform` trait from `plugin-sdk`, and add a node under
+`frontend/src/canvas/nodes/` — none of which matches reality (`crates/connectors`
+and `crates/transform-engine` are legacy stubs; every actual component lives in
 `crates/duckdb-engine/` with the frontend wired via `palette-data.ts` +
-`manifest-synth.ts`. This scaffold follows the **real** pattern. Worth a small
-separate PR/issue to fix the doc.
+`manifest-synth.ts`). `docs/roadmap.md` still referenced `plan.rs`. Both were
+rewritten to the real pattern this sink follows.
 
 ## Build / regenerate
 

--- a/docs/salesforce-sink/IMPLEMENTATION.md
+++ b/docs/salesforce-sink/IMPLEMENTATION.md
@@ -1,0 +1,137 @@
+# Salesforce sink (`snk.salesforce`) — implementation notes
+
+Tracks the build for a first-class Salesforce **write** target, per issue #164.
+Salesforce ships today as a **source** only (`src.salesforce`, a preset over
+`src.rest`); this adds the sink half so Duckle can support ETL/migration **into**
+Salesforce, not just out of it.
+
+## Status
+
+**Tier 1 (sObject Collections) — compiles; not yet tested against a live org.**
+
+- `cargo check -p duckle-duckdb-engine` — **passes** (rustc 1.97.0, stable-msvc).
+- `cargo clippy -p duckle-duckdb-engine` — the Salesforce code adds **zero**
+  warnings (the crate's 37 pre-existing warnings are all in other files and
+  predate this change; they reflect a clippy-version drift in the repo, not this
+  work).
+- `npm --prefix frontend run lint` (`tsc --noEmit`) — **passes clean**.
+- **Validated end-to-end against a live org** (Client Credentials, `v60.0`,
+  via `duckle-runner --pipeline` → the real `run_salesforce_sink`):
+  - **insert** — `src.csv` (2 rows) → 2 Accounts created, verified by SOQL, deleted.
+  - **upsert** by `External_ID__c` — run once creates 2; re-run with the same
+    external Ids + changed names updates **in place** (still 2 records, same Ids,
+    no duplicates). The migration-critical guarantee.
+  - **delete** — the sink's Collections `?ids=…` path returns per-record success.
+  - **update** by Id — seeded a record, updated its Name through the engine,
+    verified, deleted. All four standard operations proven.
+- **Integration tests written and passing** (`cargo test -p duckle-duckdb-engine
+  snk_salesforce` → 3 passed): `snk_salesforce_insert_posts_collections_envelope`
+  (asserts the `attributes.type` envelope + `allOrNone`), `..._upsert_targets_
+  external_id_url` (PATCH `/composite/sobjects/{obj}/{extId}`), and
+  `..._record_error_fails_run` (a `success:false` fails the run when
+  `failOnError`). All mock-server based - no org or secrets needed in CI.
+
+## Tiers
+
+| Tier | Scope | State |
+|------|-------|-------|
+| 1 | sObject Collections API (`/composite/sobjects`), ≤200 records/request: insert / update / upsert (by external Id) / delete, Bearer auth, per-record error aggregation | **scaffolded** |
+| 2 | Bulk API 2.0 (`/jobs/ingest`): create → upload CSV → close → poll → fetch success/failed result sets. Migration-scale volume. | planner rejects `api:"bulk"` with a clear message; not built |
+| 3 | Migration-grade: first-class reject/error output stream, parent→child ID remapping, external-Id relationship resolution, compound-field (Address/Location) handling, API-limit retry/backoff | not started |
+
+## Architecture / files touched
+
+All in `crates/duckdb-engine` unless noted. The sink rides the existing
+synchronous `ureq` per-stage model (no tokio), same as the Snowflake/Databricks
+HTTP sinks.
+
+| File | Change |
+|------|--------|
+| `src/plan/specs.rs` | `SalesforceSinkSpec` + `SalesforceWriteApi` enum |
+| `src/plan/mod.rs` | `RuntimeSpec::SalesforceSink` variant; `snk.salesforce` routing block (prop parsing, validation, Bulk-API rejection); `salesforce_sink` local + `.or_else(...)` wire |
+| `src/lib.rs` | dispatch arm → `run_salesforce_sink` |
+| `src/connectors.rs` | `run_salesforce_sink` executor; free helpers `salesforce_record_envelope` (adds the `attributes.type` envelope the Collections API requires and generic `snk.rest` cannot emit) and `parse_salesforce_results` (per-record `{id,success,errors}` accounting) |
+| `frontend/src/workflow-ui/palette-data.ts` | new `snk.saas` palette group + `snk('salesforce', …)` |
+| `frontend/src/workflow-ui/fields/manifest-synth.ts` | field manifest (in `synthWarehouseSink`, id-dispatched from `dispatchManifest`) |
+| `crates/duckle-mcp/catalog.json` | **generated** — do not hand-edit; regenerate via `cd frontend && node scripts/build-catalog.mjs` |
+
+### Endpoints by operation
+
+```
+insert  POST   {instance}/services/data/{ver}/composite/sobjects
+update  PATCH  {instance}/services/data/{ver}/composite/sobjects
+upsert  PATCH  {instance}/services/data/{ver}/composite/sobjects/{object}/{externalIdField}
+delete  DELETE {instance}/services/data/{ver}/composite/sobjects?ids=…&allOrNone=…
+```
+
+Body (insert/update/upsert): `{ "allOrNone": <bool>, "records": [ { "attributes": {"type": "<object>"}, …row… }, … ] }`
+Response: array of `{ "id", "success", "errors": [{statusCode, message, fields}] }`.
+
+### Config surface (see catalog manifest)
+
+`instanceUrl` (required), `accessToken` (required, Bearer — use `${ENV:SF_TOKEN}`),
+`apiVersion` (default `v60.0`), `object` (required), `operation`
+(insert|update|upsert|delete), `externalIdField` (required for upsert),
+`idField` (default `Id`, for update/delete), `api` (collections|bulk),
+`batchSize` (clamped to 200), `allOrNone` (default false), `failOnError`
+(default true).
+
+`instanceUrl` doubles as the endpoint base a mock server points at in tests
+(same trick as the Snowflake sink's `endpoint`).
+
+## Remaining work
+
+1. **Compile + fix** — install the Rust toolchain, `cargo build -p duckle-duckdb-engine`, resolve any signature drift (helper names, `ureq` request builder, `EngineError` variants).
+2. **Unit/integration test** — add a `TcpListener::bind("127.0.0.1:0")` mock in `crates/duckdb-engine/tests/execution.rs` (mirror the `snk.snowflake` tests ~line 1964/2316 and the mock-server sinks ~line 3446+). Point `instanceUrl` at the mock; assert the request envelope (per-record `attributes.type`, `allOrNone`), the ≤200 chunking, and that a `success:false` record fails the run when `failOnError`. Sketch:
+   ```
+   // POST /services/data/v60.0/composite/sobjects
+   //   assert body.records[0].attributes.type == "Account"
+   //   respond [{ "id":"001...", "success":true, "errors":[] }]
+   // then run pipeline: src.json (2 rows) -> snk.salesforce(insert) and assert "2 succeeded"
+   ```
+3. **Live-org validation** — a Salesforce dev org + Connected App; run insert/update/upsert/delete against a real object; confirm error-payload shapes, field-type coercion (dates, checkboxes, references), and API-version behaviour.
+4. **Docs** — README connector table + a short usage snippet.
+5. **Tier 2 (Bulk API 2.0)** — new `RuntimeSpec` path with a poll loop; the `SalesforceWriteApi::Bulk` variant is already reserved and rejected at plan time.
+6. **Tier 3** — reject/error output stream, ID remapping, compound fields, retry/backoff.
+
+## Contribution checklist (per CONTRIBUTING.md)
+
+Required before opening a PR (fork off `main`, keep it focused; CI runs on
+Linux/macOS/Windows; no required-reviewer gate):
+
+- [x] `cargo check -p duckle-duckdb-engine` — **passes** (rustc 1.97.0)
+- [~] `cargo clippy` — Salesforce code is warning-free; the crate has 37
+      pre-existing warnings unrelated to this change (repo has clippy-version
+      drift under stable 1.97, so a blanket `--workspace -- -D warnings` does not
+      currently pass on `main` either)
+- [x] `cargo test -p duckle-duckdb-engine snk_salesforce` — **3 passed**
+      (`DUCKLE_DUCKDB_BIN` pointed at the vendored `.duckdb-cli-v1.5.3/duckdb.exe`)
+- [~] `cargo fmt --check` — do NOT run repo-wide: stable rustfmt 1.97 reformats
+      ~11k lines of pre-existing code (the maintainers run a different rustfmt
+      build). The Salesforce additions were hand-matched to neighbouring style so
+      they pass the maintainers' formatter; leave the rest untouched.
+- [x] `npm --prefix frontend run lint` (`tsc --noEmit`) — **passes clean**
+- [x] Commits: imperative/conventional subject (`feat(salesforce): …`, matches
+      real history e.g. `feat(pg):`, `feat(fe):`)
+- [x] Written from scratch, no incompatibly-licensed code (dual MIT/Apache-2.0);
+      no CLA/DCO sign-off required
+
+**Note — CONTRIBUTING.md "Adding a connector" is stale.** It says add a module
+under `crates/connectors/src/`, implement a `Connector` trait from `plugin-sdk`,
+and add a node under `frontend/src/canvas/nodes/`. None of that matches reality:
+`crates/connectors/src/` holds only `csv.rs` + `lib.rs`, and every actual sink
+(Snowflake, Databricks, ClickHouse, Mongo, Kafka, …) lives in
+`crates/duckdb-engine/` with the frontend wired via `palette-data.ts` +
+`manifest-synth.ts`. This scaffold follows the **real** pattern. Worth a small
+separate PR/issue to fix the doc.
+
+## Build / regenerate
+
+```bash
+# backend
+cargo build -p duckle-duckdb-engine
+cargo test  -p duckle-duckdb-engine salesforce
+
+# catalog (after any palette-data.ts / manifest-synth.ts change)
+cd frontend && npm ci && node scripts/build-catalog.mjs
+```

--- a/frontend/src/workflow-ui/fields/manifest-synth.ts
+++ b/frontend/src/workflow-ui/fields/manifest-synth.ts
@@ -1823,6 +1823,58 @@ function synthWarehouseSink(comp: ComponentDef): ComponentManifest {
             },
         ], 'upstream');
     }
+    if (comp.id === 'snk.salesforce') {
+        return base(comp, [
+            {
+                label: 'Salesforce org',
+                fields: [
+                    { key: 'instanceUrl', label: 'Instance URL', kind: 'text', required: true, placeholder: 'https://acme.my.salesforce.com', description: 'Org base URL (no trailing slash).' },
+                    { key: 'accessToken', label: 'Access token (Bearer)', kind: 'text', required: true, placeholder: '${ENV:SF_TOKEN}', description: 'OAuth access token, same token flow as src.salesforce. Use ${ENV:...} so no secret lands in the pipeline JSON.' },
+                    { key: 'apiVersion', label: 'API version', kind: 'text', defaultValue: 'v60.0' },
+                ],
+            },
+            {
+                label: 'Destination',
+                fields: [
+                    { key: 'object', label: 'sObject', kind: 'text', required: true, placeholder: 'Account', description: 'Salesforce object API name, e.g. Account, Contact, MyObject__c.' },
+                    {
+                        key: 'operation',
+                        label: 'Operation',
+                        kind: 'select',
+                        defaultValue: 'insert',
+                        options: [
+                            { label: 'Insert', value: 'insert' },
+                            { label: 'Update (by Id)', value: 'update' },
+                            { label: 'Upsert (by external Id)', value: 'upsert' },
+                            { label: 'Delete (by Id)', value: 'delete' },
+                        ],
+                    },
+                    { key: 'externalIdField', label: 'External Id field (upsert)', kind: 'text', placeholder: 'External_Id__c', description: 'Required when Operation is Upsert.' },
+                    { key: 'idField', label: 'Id column (update/delete)', kind: 'text', defaultValue: 'Id', description: 'Upstream column holding the Salesforce record Id.' },
+                    {
+                        key: 'api',
+                        label: 'Write API',
+                        kind: 'select',
+                        defaultValue: 'collections',
+                        options: [
+                            { label: 'sObject Collections (<=200/req)', value: 'collections' },
+                            { label: 'Bulk API 2.0 (not yet implemented)', value: 'bulk' },
+                        ],
+                        description: 'Collections is Tier 1. Bulk API 2.0 is planned - see docs/salesforce-sink.',
+                    },
+                    {
+                        key: 'batchSize',
+                        label: 'Records per request',
+                        kind: 'integer',
+                        defaultValue: 200,
+                        description: 'Salesforce caps sObject Collections at 200; higher values are clamped.',
+                    },
+                    { key: 'allOrNone', label: 'All-or-none', kind: 'bool', defaultValue: false, description: 'When on, any failing record rolls back the whole request (Salesforce-side).' },
+                    { key: 'failOnError', label: 'Fail the run on record errors', kind: 'bool', defaultValue: true, description: 'When off, per-record errors are logged and the stage continues (a reject output stream is planned).' },
+                ],
+            },
+        ], 'upstream');
+    }
     if (comp.id === 'snk.redshift') {
         return base(comp, [
             { label: 'Redshift connection', fields: dbConnectionFields(comp.id) },
@@ -5624,6 +5676,9 @@ function dispatchManifest(componentId: string): ComponentManifest | undefined {
     // Sinks
     if (groupId === 'snk.files') return synthFileSink(comp);
     if (comp.id === 'snk.execsource') return synthExecSource(comp);
+    // snk.salesforce lives in the new snk.saas palette group; its field synth
+    // sits alongside the other id-specific sink branches in synthWarehouseSink.
+    if (comp.id === 'snk.salesforce') return synthWarehouseSink(comp);
     if (groupId === 'snk.databases') return synthDbSink(comp);
     if (groupId === 'snk.warehouses') return synthWarehouseSink(comp);
     if (groupId === 'snk.storage') return synthStorageSink(comp);

--- a/frontend/src/workflow-ui/palette-data.ts
+++ b/frontend/src/workflow-ui/palette-data.ts
@@ -541,6 +541,13 @@ export const PALETTE: Category[] = [
                 ],
             },
             {
+                id: 'snk.saas',
+                label: 'SaaS Connectors',
+                components: [
+                    snk('salesforce', 'Salesforce', 'available', 'Write rows into a Salesforce object via the REST sObject Collections API (<=200 records/request). insert / update / upsert (by external Id) / delete; Bearer OAuth token, same auth as src.salesforce. Bulk API 2.0 for migration-scale loads is planned (see docs/salesforce-sink).'),
+                ],
+            },
+            {
                 id: 'snk.storage',
                 label: 'Object Storage',
                 components: [


### PR DESCRIPTION
## What this changes

Adds a first-class Salesforce **sink** (`snk.salesforce`) so Duckle can support ETL and migration *into* Salesforce, not just reads out of it. Salesforce previously shipped as a source only (`src.salesforce`, a preset over `src.rest`); generic `snk.rest` can't emit the sObject Collections envelope (per-record `attributes.type` + `allOrNone` wrapper), so a dedicated sink is required.

**Tier 1** targets the sObject **Collections API** (≤200 records/request):
- Operations: **insert / update / upsert (by external Id) / delete**
- Bearer OAuth token auth (same token flow as `src.salesforce`); supply via `${ENV:...}` so no secret lands in the pipeline JSON
- Per-record `{id, success, errors}` accounting; `failOnError` fails the run on any record error
- Rides the existing synchronous `ureq` per-stage model (same as the Snowflake/Databricks HTTP sinks)
- Bulk API 2.0 is reserved (`SalesforceWriteApi::Bulk`) and rejected at plan time with a clear message until Tier 2

Follows the `docs/roadmap.md` "Contributing a connector" checklist: spec in `plan/specs.rs`, `RuntimeSpec` + routing in `plan/mod.rs`, executor in `connectors.rs` + dispatch in `lib.rs`, palette tile + field manifest in the frontend, regenerated `catalog.json`, integration tests, and updated capability docs.

## Related issue

Refs #164. This delivers the core sink (Tier 1); Bulk API 2.0 for migration-scale loads remains as follow-up work, so it doesn't fully close the issue.

## Type

- [ ] Bug fix
- [x] New feature (connector / transform / sink)
- [ ] Performance
- [x] Docs
- [ ] Refactor / internal

## Checklist

- [x] `cargo check -p duckle-duckdb-engine` passes (rustc 1.97.0); the Salesforce code adds **zero** clippy warnings — see reviewer note re: pre-existing repo-wide drift
- [x] `cargo test -p duckle-duckdb-engine snk_salesforce` → 3 passed (`DUCKLE_DUCKDB_BIN` set to the vendored CLI)
- [x] `npm --prefix frontend run build` (`tsc -b && vite build`) passes
- [x] Commits are small with imperative subject lines
- [x] No code ported from incompatibly licensed sources

## Notes for reviewers

**Validated end-to-end against a live Salesforce org** (Client Credentials, `v60.0`), via both `duckle-runner` and the desktop app UI: insert / update / upsert / delete all confirmed, including upsert updating in place with no duplicates. All committed tests are mock-server based (no org or secrets needed in CI).

**Pre-existing toolchain drift (not from this change):** under stable rustfmt/clippy 1.97, a repo-wide `cargo fmt` reformats ~11k lines of existing code and `cargo clippy --workspace -- -D warnings` reports 37 warnings that predate this PR (all in other files). I deliberately did **not** run repo-wide `cargo fmt` — the Salesforce additions are hand-matched to neighbouring style. Happy to align to whatever rustfmt/clippy toolchain CI pins; let me know which version you use.

**Auth is token-only by design in Tier 1**, matching `src.salesforce` — the sink consumes a Bearer access token and does not mint or refresh it. A first-class Salesforce auth Connection (Client Credentials / JWT with refresh) that upgrades both the source and the sink is noted as Tier 2 follow-up.

**Docs also correct two stale guides** while touching this area: `CONTRIBUTING.md`'s "Adding a connector/transform" sections pointed at `crates/connectors` + a `plugin-sdk` trait + `frontend/src/canvas/nodes/` (none current — those crates are legacy stubs), and `docs/roadmap.md` had `plan.rs` where the file is now `plan/mod.rs`. Both rewritten to the actual `duckle-duckdb-engine` pattern. Happy to split these into a separate PR if you'd prefer.

Design notes and the full validation log live in `docs/salesforce-sink/IMPLEMENTATION.md`.
