### PR TITLE
feat(salesforce): #166 stage 2 - saved encrypted connection + run-time ref resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,3 +338,39 @@ jobs:
           DUCKLE_MINIO_ACCESS_KEY: minioadmin
           DUCKLE_MINIO_SECRET_KEY: minioadmin
         run: cargo test -p duckle-duckdb-engine --test execution -- minio_
+
+  # Live Salesforce integration (#166): runs the credential-free lifecycle
+  # suite in docs/salesforce-sink/live-suite against a REAL org - insert ->
+  # retrieve -> update (remapped idField) -> upsert -> retrieve -> delete via a
+  # saved connection, plus bearer back-compat and failure modes. There is no
+  # container for a Salesforce org, so unlike the jobs above this one is
+  # OPT-IN: set the repository variable SF_LIVE_TESTS=true and the secrets
+  # SF_INSTANCE_URL / SF_CLIENT_ID / SF_CLIENT_SECRET (a dev org with an
+  # External_ID__c external-Id field on Account and a client-credentials app -
+  # see the suite README). Skipped otherwise, including on fork PRs, which
+  # never see repository secrets. Suite records are keyed SUITE-* and
+  # self-clean. Mock-level Salesforce coverage runs unconditionally in the
+  # rust matrix (engine execution tests + duckle-secrets' connection_e2e).
+  salesforce-integration:
+    if: vars.SF_LIVE_TESTS == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install DuckDB CLI
+        run: |
+          set -e
+          curl -L -o duckdb.zip https://github.com/duckdb/duckdb/releases/download/v1.5.4/duckdb_cli-linux-amd64.zip
+          mkdir -p "$RUNNER_TEMP/duckdb"
+          unzip -o duckdb.zip -d "$RUNNER_TEMP/duckdb"
+          echo "DUCKLE_DUCKDB_BIN=$RUNNER_TEMP/duckdb/duckdb" >> "$GITHUB_ENV"
+      - name: Build duckle-runner
+        run: cargo build -p duckle-runner
+      - name: Run Salesforce live suite
+        env:
+          SF_INSTANCE_URL: ${{ secrets.SF_INSTANCE_URL }}
+          SF_CLIENT_ID: ${{ secrets.SF_CLIENT_ID }}
+          SF_CLIENT_SECRET: ${{ secrets.SF_CLIENT_SECRET }}
+          DUCKLE_RUNNER: ${{ github.workspace }}/target/debug/duckle-runner
+        run: bash docs/salesforce-sink/live-suite/run-suite.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,8 +4004,6 @@ dependencies = [
 name = "duckle-desktop"
 version = "0.0.1"
 dependencies = [
- "aes-gcm",
- "base64 0.22.1",
  "chrono",
  "duckle-connectors",
  "duckle-duckdb-engine",
@@ -4013,8 +4011,8 @@ dependencies = [
  "duckle-plugin-sdk",
  "duckle-runtime",
  "duckle-scheduler",
+ "duckle-secrets",
  "flate2",
- "getrandom 0.2.17",
  "include_dir",
  "reqwest 0.12.28",
  "serde",
@@ -4160,6 +4158,7 @@ dependencies = [
  "chrono",
  "cron",
  "duckle-duckdb-engine",
+ "duckle-secrets",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "regex",
@@ -4188,6 +4187,7 @@ dependencies = [
  "chrono",
  "cron",
  "duckle-duckdb-engine",
+ "duckle-secrets",
  "notify",
  "notify-debouncer-mini",
  "serde",
@@ -4197,6 +4197,17 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "duckle-secrets"
+version = "0.0.1"
+dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
+ "duckle-metadata",
+ "getrandom 0.2.17",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4205,9 +4205,11 @@ version = "0.0.1"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
+ "duckle-duckdb-engine",
  "duckle-metadata",
  "getrandom 0.2.17",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/plugin-sdk",
     "crates/metadata",
     "crates/scheduler",
+    "crates/duckle-secrets",
 ]
 
 [workspace.package]
@@ -40,6 +41,7 @@ duckle-execution-core = { path = "crates/execution-core", version = "0.0.1" }
 duckle-plugin-sdk = { path = "crates/plugin-sdk", version = "0.0.1" }
 duckle-metadata = { path = "crates/metadata", version = "0.0.1" }
 duckle-scheduler = { path = "crates/scheduler", version = "0.0.1" }
+duckle-secrets = { path = "crates/duckle-secrets", version = "0.0.1" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -36,10 +36,9 @@ tauri-plugin-opener = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 # Encryption at rest for saved connection secrets + the cached git PAT
-# (secrets.rs). Same AES-256-GCM scheme the duckle-runner bundle uses.
-aes-gcm = "0.10"
-base64 = "0.22"
-getrandom = "0.2"
+# (secrets.rs). The AES-256-GCM scheme lives in the shared duckle-secrets
+# crate so the headless runner decrypts saved connections the same way (#166).
+duckle-secrets = { workspace = true }
 # Parse the GitHub release asset's RFC3339 upload time + format the embedded
 # build time for the update-available check (update_check.rs).
 chrono = { workspace = true }

--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -330,7 +330,10 @@ async fn run_pipeline(
     // Resolve ${ENV:NAME} from the OS environment before running, so canvas runs
     // see process env vars like the headless runner does (issue #137). The
     // frontend already resolved ${workspace}/${context}/date builtins.
+    // Saved Salesforce connections resolve first (#166 stage 2) so a
+    // connection field stored as ${ENV:...} still expands below.
     let mut pipeline = pipeline;
+    resolve_saved_connections(&mut pipeline, &workspace_path)?;
     duckle_duckdb_engine::context::apply_env(&mut pipeline);
     let name = pipeline_name.clone();
     let joined = tokio::task::spawn_blocking(move || {
@@ -343,6 +346,27 @@ async fn run_pipeline(
     let result = joined.map_err(|e| e.to_string())?;
     record_history(&pipeline_id, &workspace_path, &result, "manual");
     Ok(result)
+}
+
+/// #166 stage 2: expand saved Salesforce connection refs into node auth props
+/// before the `${ENV:}` pass, so the node stores only a `connectionRef` and
+/// secrets never land in the pipeline file. A ref without a workspace to
+/// resolve it from is a clear error rather than a downstream auth failure.
+fn resolve_saved_connections(
+    pipeline: &mut PipelineDoc,
+    workspace_path: &Option<String>,
+) -> Result<(), String> {
+    match workspace_path {
+        Some(ws) => {
+            duckle_secrets::resolve_connection_refs(std::path::Path::new(ws), &mut pipeline.nodes)
+        }
+        None if duckle_secrets::has_connection_refs(&pipeline.nodes) => Err(
+            "this pipeline uses a saved Salesforce connection; run it from a workspace \
+             so the connection can be resolved"
+            .into(),
+        ),
+        None => Ok(()),
+    }
 }
 
 fn record_history(
@@ -373,8 +397,10 @@ async fn run_pipeline_partial(
 ) -> Result<RunResult, String> {
     let engine = engine()?.for_new_run();
     *CURRENT_RUN.lock().unwrap_or_else(|p| p.into_inner()) = Some(engine.clone());
-    // Resolve ${ENV:NAME} from the OS environment before running (issue #137).
+    // Resolve ${ENV:NAME} from the OS environment before running (issue #137);
+    // saved Salesforce connections resolve first (#166 stage 2).
     let mut pipeline = pipeline;
+    resolve_saved_connections(&mut pipeline, &workspace_path)?;
     duckle_duckdb_engine::context::apply_env(&mut pipeline);
     let target = target_node_id;
     let name = pipeline_name.clone();

--- a/apps/desktop/src/secrets.rs
+++ b/apps/desktop/src/secrets.rs
@@ -1,167 +1,19 @@
 //! Encryption at rest for saved connection secrets and the cached git PAT.
 //!
-//! Sensitive connection fields (passwords, tokens, keys) are encrypted with a
-//! per-workspace AES-256-GCM key kept at `<workspace>/.duckle/keys/secret.key`
-//! (owner-only on unix, excluded from version control). The connection JSON in
-//! `<workspace>/connections/` therefore holds ciphertext for those fields, so
-//! the folder is safe to commit or share as long as `.duckle/keys/` is not.
-//! `${...}` placeholders are never encrypted - they resolve from the
-//! environment at run time.
+//! The AES-256-GCM implementation lives in the shared `duckle-secrets` crate
+//! (#166 stage 2) so the headless runner resolves saved connections through
+//! the exact same decrypt path; this module keeps the desktop-facing Tauri
+//! commands and re-exports the primitives `workspace_git.rs` uses.
 
-use aes_gcm::aead::Aead;
-use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
-use base64::Engine;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-const ENC_PREFIX: &str = "enc:v1:";
-
-/// Connection-payload fields (by name) that hold a secret and get encrypted.
-const SENSITIVE_KEYS: &[&str] = &[
-    "password",
-    "secretKey",
-    "accessKey",
-    "accountKey",
-    "sessionToken",
-    "pat",
-    "token",
-    "apiKey",
-    "passphrase",
-    "secret",
-];
-
-fn key_path(workspace: &Path) -> PathBuf {
-    workspace.join(".duckle").join("keys").join("secret.key")
-}
-
-/// Load the workspace key. With `create`, a fresh random 32-byte key is
-/// generated and persisted on first use; without it, a missing key is an
-/// error (so a workspace shared without the key decrypts to nothing rather
-/// than minting a wrong key).
-pub(crate) fn workspace_key(workspace: &Path, create: bool) -> Result<[u8; 32], String> {
-    let path = key_path(workspace);
-    if let Ok(bytes) = std::fs::read(&path) {
-        if bytes.len() == 32 {
-            let mut k = [0u8; 32];
-            k.copy_from_slice(&bytes);
-            return Ok(k);
-        }
-    }
-    if !create {
-        return Err("no workspace key".into());
-    }
-    let mut k = [0u8; 32];
-    getrandom::getrandom(&mut k).map_err(|e| format!("key rng: {}", e))?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("create keys dir: {}", e))?;
-    }
-    // Create the key file owner-only from the start; writing first and
-    // chmod'ing after left a brief world-readable window (TOCTOU).
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&path)
-            .map_err(|e| format!("create key: {}", e))?;
-        f.write_all(&k).map_err(|e| format!("write key: {}", e))?;
-    }
-    #[cfg(not(unix))]
-    std::fs::write(&path, k).map_err(|e| format!("write key: {}", e))?;
-    Ok(k)
-}
-
-pub(crate) fn is_encrypted(s: &str) -> bool {
-    s.starts_with(ENC_PREFIX)
-}
-
-/// Encrypt plaintext into an `enc:v1:<base64(nonce || ciphertext)>` token.
-pub(crate) fn encrypt_value(key: &[u8; 32], plaintext: &str) -> Result<String, String> {
-    let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| format!("cipher init: {}", e))?;
-    let mut nonce_bytes = [0u8; 12];
-    getrandom::getrandom(&mut nonce_bytes).map_err(|e| format!("nonce rng: {}", e))?;
-    let ciphertext = cipher
-        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_bytes())
-        .map_err(|e| format!("encrypt: {}", e))?;
-    let mut payload = Vec::with_capacity(12 + ciphertext.len());
-    payload.extend_from_slice(&nonce_bytes);
-    payload.extend_from_slice(&ciphertext);
-    Ok(format!(
-        "{}{}",
-        ENC_PREFIX,
-        base64::engine::general_purpose::STANDARD.encode(payload)
-    ))
-}
-
-/// Decrypt an `enc:v1:` token back to plaintext.
-pub(crate) fn decrypt_value(key: &[u8; 32], blob: &str) -> Result<String, String> {
-    let b64 = blob.strip_prefix(ENC_PREFIX).ok_or("not an encrypted value")?;
-    let raw = base64::engine::general_purpose::STANDARD
-        .decode(b64)
-        .map_err(|e| format!("base64: {}", e))?;
-    if raw.len() < 12 {
-        return Err("ciphertext too short".into());
-    }
-    let (nonce_bytes, ciphertext) = raw.split_at(12);
-    let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| format!("cipher init: {}", e))?;
-    let plain = cipher
-        .decrypt(Nonce::from_slice(nonce_bytes), ciphertext)
-        .map_err(|e| format!("decrypt: {}", e))?;
-    String::from_utf8(plain).map_err(|e| format!("utf8: {}", e))
-}
-
-/// Walk a JSON value, encrypting or decrypting the sensitive string fields in
-/// place. Already-encrypted values and `${...}` placeholders are left alone.
-fn transform(value: &mut serde_json::Value, key: &[u8; 32], encrypting: bool) -> Result<(), String> {
-    match value {
-        serde_json::Value::Object(map) => {
-            for (k, v) in map.iter_mut() {
-                if let Some(s) = v.as_str() {
-                    if encrypting {
-                        if SENSITIVE_KEYS.contains(&k.as_str())
-                            && !s.is_empty()
-                            && !is_encrypted(s)
-                            && !s.starts_with("${")
-                        {
-                            // Propagate: never silently leave a secret in
-                            // plaintext (the file is meant to hold ciphertext).
-                            let enc = encrypt_value(key, s)?;
-                            *v = serde_json::Value::String(enc);
-                        }
-                    } else if is_encrypted(s) {
-                        // Decrypt stays lenient: a missing/legacy value loads
-                        // unchanged rather than failing the read.
-                        if let Ok(dec) = decrypt_value(key, s) {
-                            *v = serde_json::Value::String(dec);
-                        }
-                    }
-                } else {
-                    transform(v, key, encrypting)?;
-                }
-            }
-        }
-        serde_json::Value::Array(arr) => {
-            for v in arr.iter_mut() {
-                transform(v, key, encrypting)?;
-            }
-        }
-        _ => {}
-    }
-    Ok(())
-}
+pub(crate) use duckle_secrets::{decrypt_value, encrypt_value, is_encrypted, workspace_key};
 
 /// Encrypt the sensitive fields of a connection payload JSON before it is
 /// written to disk.
 #[tauri::command]
 pub fn connection_encrypt_payload(workspace: String, payload_json: String) -> Result<String, String> {
-    let key = workspace_key(Path::new(&workspace), true)?;
-    let mut v: serde_json::Value =
-        serde_json::from_str(&payload_json).map_err(|e| format!("json: {}", e))?;
-    transform(&mut v, &key, true)?;
-    serde_json::to_string(&v).map_err(|e| format!("json: {}", e))
+    duckle_secrets::encrypt_payload_json(Path::new(&workspace), &payload_json)
 }
 
 /// Decrypt the sensitive fields of a connection payload JSON after it is read
@@ -169,49 +21,5 @@ pub fn connection_encrypt_payload(workspace: String, payload_json: String) -> Re
 /// unchanged so plaintext / legacy values still load.
 #[tauri::command]
 pub fn connection_decrypt_payload(workspace: String, payload_json: String) -> Result<String, String> {
-    let key = match workspace_key(Path::new(&workspace), false) {
-        Ok(k) => k,
-        Err(_) => return Ok(payload_json),
-    };
-    let mut v: serde_json::Value =
-        serde_json::from_str(&payload_json).map_err(|e| format!("json: {}", e))?;
-    transform(&mut v, &key, false)?;
-    serde_json::to_string(&v).map_err(|e| format!("json: {}", e))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn round_trip_encrypts_only_sensitive_fields() {
-        let dir = std::env::temp_dir().join(format!("duckle_sec_{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&dir);
-        let ws = dir.to_string_lossy().to_string();
-
-        let payload = r#"{"kind":"postgres","host":"db.local","username":"u","password":"s3cr3t","port":5432}"#;
-        let enc = connection_encrypt_payload(ws.clone(), payload.to_string()).unwrap();
-        // Non-secret fields stay readable; the password becomes ciphertext.
-        assert!(enc.contains("\"host\":\"db.local\""), "host should be plaintext: {}", enc);
-        assert!(enc.contains("\"username\":\"u\""), "username should be plaintext: {}", enc);
-        assert!(enc.contains("enc:v1:"), "password should be encrypted: {}", enc);
-        assert!(!enc.contains("s3cr3t"), "plaintext secret leaked: {}", enc);
-
-        let dec = connection_decrypt_payload(ws, enc).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&dec).unwrap();
-        assert_eq!(v["password"], "s3cr3t");
-        assert_eq!(v["host"], "db.local");
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn env_placeholders_are_not_encrypted() {
-        let dir = std::env::temp_dir().join(format!("duckle_sec_env_{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&dir);
-        let ws = dir.to_string_lossy().to_string();
-        let payload = r#"{"password":"${ENV:PGPASSWORD}"}"#;
-        let enc = connection_encrypt_payload(ws, payload.to_string()).unwrap();
-        assert!(enc.contains("${ENV:PGPASSWORD}"), "placeholder must survive: {}", enc);
-        let _ = std::fs::remove_dir_all(&dir);
-    }
+    duckle_secrets::decrypt_payload_json(Path::new(&workspace), &payload_json)
 }

--- a/crates/duckle-mcp/catalog.json
+++ b/crates/duckle-mcp/catalog.json
@@ -30243,6 +30243,15 @@
             "label": "Salesforce org",
             "fields": [
               {
+                "key": "connectionRef",
+                "label": "Saved connection",
+                "kind": "connection-ref",
+                "accepts": [
+                  "salesforce"
+                ],
+                "description": "Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; the auth fields below are ignored when set."
+              },
+              {
                 "key": "authMode",
                 "label": "Auth mode",
                 "kind": "select",
@@ -39177,6 +39186,15 @@
           {
             "label": "Auth",
             "fields": [
+              {
+                "key": "connectionRef",
+                "label": "Saved connection",
+                "kind": "connection-ref",
+                "accepts": [
+                  "salesforce"
+                ],
+                "description": "Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; the auth fields below are ignored when set."
+              },
               {
                 "key": "authType",
                 "label": "Auth type",

--- a/crates/duckle-mcp/src/tools.rs
+++ b/crates/duckle-mcp/src/tools.rs
@@ -1206,6 +1206,8 @@ fn is_secret_key(lower_key: &str) -> bool {
     const KEYS: &[&str] = &[
         "password", "secretkey", "accesskey", "accountkey", "accountname",
         "sessiontoken", "pat", "token", "apikey", "passphrase", "secret",
+        // Salesforce saved connection (#166 stage 2).
+        "clientsecret", "accesstoken",
     ];
     KEYS.contains(&lower_key)
 }

--- a/crates/duckle-runner/Cargo.toml
+++ b/crates/duckle-runner/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 duckle-duckdb-engine = { workspace = true }
+duckle-secrets = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 regex = "1"

--- a/crates/duckle-runner/src/main.rs
+++ b/crates/duckle-runner/src/main.rs
@@ -300,6 +300,11 @@ fn run() -> Result<bool, String> {
         .or_else(|| pipeline.parent().map(Path::to_path_buf))
         .unwrap_or_else(|| PathBuf::from("."));
 
+    // Expand saved Salesforce connection refs into node auth props (#166
+    // stage 2) BEFORE the env pass, decrypting connections/<id>.json with the
+    // workspace key - same shared crate the desktop app uses, so a
+    // connection field stored as ${ENV:...} still resolves below.
+    duckle_secrets::resolve_connection_refs(&workspace, &mut doc.nodes)?;
     // Runtime ${ENV:KEY} substitution. A built bundle ships ${ENV:KEY}
     // placeholders in place of secrets; resolve them now from the
     // environment, then secrets.env, then a decrypted secrets.enc.
@@ -589,6 +594,15 @@ fn run_artifact(payload: Vec<u8>) -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    // Saved Salesforce connection refs resolve against the run-host workspace
+    // (#166 stage 2); artifacts normally ship ${ENV:} placeholders instead,
+    // but a ref-only pipeline run with DUCKLE_WORKSPACE pointed at a real
+    // workspace works, and an unresolvable ref fails with a clear error here
+    // rather than a downstream auth failure.
+    if let Err(e) = duckle_secrets::resolve_connection_refs(&ws_root, &mut doc.nodes) {
+        eprintln!("duckle-runner: {e}");
+        return ExitCode::from(2);
+    }
     if let Err(e) = apply_env_pass(&mut doc, &root, &env_file) {
         eprintln!("duckle-runner: {e}");
         return ExitCode::from(2);

--- a/crates/duckle-runner/src/serve.rs
+++ b/crates/duckle-runner/src/serve.rs
@@ -414,6 +414,11 @@ fn dispatch_cmd(stream: &mut TcpStream, state: &WebState, cmd: &str, body: &[u8]
                 Ok(d) => d,
                 Err(e) => return respond_err(stream, "400 Bad Request", &format!("bad pipeline: {}", e)),
             };
+            // Saved Salesforce connection refs resolve server-side against this
+            // workspace (#166 stage 2) - the browser never sees the secret.
+            if let Err(e) = duckle_secrets::resolve_connection_refs(&state.workspace, &mut doc.nodes) {
+                return respond_err(stream, "400 Bad Request", &e);
+            }
             duckle_duckdb_engine::context::apply_workspace_context(&mut doc, &state.workspace);
             let name = args.get("pipelineName").and_then(|v| v.as_str()).unwrap_or("web").to_string();
             let _guard = state.run_lock.lock().unwrap_or_else(|p| p.into_inner());
@@ -521,6 +526,11 @@ fn run_stream(stream: &mut TcpStream, state: &WebState, body: &[u8]) -> Result<(
         Ok(d) => d,
         Err(e) => return respond_err(stream, "400 Bad Request", &format!("bad pipeline: {}", e)),
     };
+    // Saved Salesforce connection refs resolve server-side against this
+    // workspace (#166 stage 2) - the browser never sees the secret.
+    if let Err(e) = duckle_secrets::resolve_connection_refs(&state.workspace, &mut doc.nodes) {
+        return respond_err(stream, "400 Bad Request", &e);
+    }
     duckle_duckdb_engine::context::apply_workspace_context(&mut doc, &state.workspace);
     let name = args.get("pipelineName").and_then(|v| v.as_str()).unwrap_or("web").to_string();
     // Optional run-to-here target: when set, the engine runs only the subgraph
@@ -1264,8 +1274,11 @@ fn execute_one(
     }
     let _running = RunningGuard { set: &state.running, id: id.clone() };
 
-    // Same placeholder resolution as `duckle-runner run`: ${ENV:KEY} secrets,
-    // then the dynamic ${date}/${datetime}/... builtins.
+    // Same placeholder resolution as `duckle-runner run`: saved Salesforce
+    // connection refs first (#166 stage 2, so a connection field stored as
+    // ${ENV:...} still expands), then ${ENV:KEY} secrets, then the dynamic
+    // ${date}/${datetime}/... builtins.
+    duckle_secrets::resolve_connection_refs(&state.workspace, &mut doc.nodes)?;
     let env_file = state.workspace.join("secrets.env");
     crate::apply_env_pass(&mut doc, &state.workspace, &env_file)?;
     duckle_duckdb_engine::context::apply_time_builtins(&mut doc);

--- a/crates/duckle-secrets/Cargo.toml
+++ b/crates/duckle-secrets/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "duckle-secrets"
+description = "Workspace secret encryption and saved-connection resolution shared by the desktop app and the headless runner."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+aes-gcm = "0.10"
+base64 = "0.22"
+getrandom = "0.2"
+serde_json = { workspace = true }
+duckle-metadata = { workspace = true }

--- a/crates/duckle-secrets/Cargo.toml
+++ b/crates/duckle-secrets/Cargo.toml
@@ -14,3 +14,7 @@ base64 = "0.22"
 getrandom = "0.2"
 serde_json = { workspace = true }
 duckle-metadata = { workspace = true }
+
+[dev-dependencies]
+duckle-duckdb-engine = { workspace = true }
+tempfile = "3.10"

--- a/crates/duckle-secrets/src/lib.rs
+++ b/crates/duckle-secrets/src/lib.rs
@@ -110,7 +110,9 @@ pub fn encrypt_value(key: &[u8; 32], plaintext: &str) -> Result<String, String> 
 
 /// Decrypt an `enc:v1:` token back to plaintext.
 pub fn decrypt_value(key: &[u8; 32], blob: &str) -> Result<String, String> {
-    let b64 = blob.strip_prefix(ENC_PREFIX).ok_or("not an encrypted value")?;
+    let b64 = blob
+        .strip_prefix(ENC_PREFIX)
+        .ok_or("not an encrypted value")?;
     let raw = base64::engine::general_purpose::STANDARD
         .decode(b64)
         .map_err(|e| format!("base64: {}", e))?;
@@ -241,7 +243,9 @@ pub fn load_connection(workspace: &Path, id: &str) -> Result<JsonValue, String> 
 
 /// The payload holds a connection JSON object; read a non-empty string field.
 fn conn_str<'a>(conn: &'a JsonValue, key: &str) -> Option<&'a str> {
-    conn.get(key).and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+    conn.get(key)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
 }
 
 /// Expand a `connectionRef` on a Salesforce node's properties into the auth
@@ -277,7 +281,9 @@ pub fn resolve_connection_ref_props(
     }
     // Same aliases the engine's salesforce_oauth_from_props accepts.
     let client_credentials = matches!(
-        conn.get("authMode").and_then(|v| v.as_str()).unwrap_or("bearer"),
+        conn.get("authMode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("bearer"),
         "clientCredentials" | "client_credentials" | "oauth" | "oauth_client_credentials"
     );
     let map = props
@@ -288,13 +294,25 @@ pub fn resolve_connection_ref_props(
     if is_sink {
         map.insert(
             "authMode".into(),
-            JsonValue::String(if client_credentials { "clientCredentials" } else { "bearer" }.into()),
+            JsonValue::String(
+                if client_credentials {
+                    "clientCredentials"
+                } else {
+                    "bearer"
+                }
+                .into(),
+            ),
         );
     } else {
         map.insert(
             "authType".into(),
             JsonValue::String(
-                if client_credentials { "oauth_client_credentials" } else { "bearer" }.into(),
+                if client_credentials {
+                    "oauth_client_credentials"
+                } else {
+                    "bearer"
+                }
+                .into(),
             ),
         );
     }
@@ -328,10 +346,7 @@ pub fn resolve_connection_ref_props(
 /// Resolve saved-connection references on every Salesforce node in a pipeline
 /// document, in place. Call BEFORE the `${ENV:...}` pass so a connection field
 /// stored as a placeholder still expands afterwards.
-pub fn resolve_connection_refs(
-    workspace: &Path,
-    nodes: &mut [PipelineNode],
-) -> Result<(), String> {
+pub fn resolve_connection_refs(workspace: &Path, nodes: &mut [PipelineNode]) -> Result<(), String> {
     for node in nodes.iter_mut() {
         let Some(component_id) = node.data.component_id.clone() else {
             continue;
@@ -398,9 +413,21 @@ mod tests {
         let payload = r#"{"kind":"postgres","host":"db.local","username":"u","password":"s3cr3t","port":5432}"#;
         let enc = encrypt_payload_json(&ws, payload).unwrap();
         // Non-secret fields stay readable; the password becomes ciphertext.
-        assert!(enc.contains("\"host\":\"db.local\""), "host should be plaintext: {}", enc);
-        assert!(enc.contains("\"username\":\"u\""), "username should be plaintext: {}", enc);
-        assert!(enc.contains("enc:v1:"), "password should be encrypted: {}", enc);
+        assert!(
+            enc.contains("\"host\":\"db.local\""),
+            "host should be plaintext: {}",
+            enc
+        );
+        assert!(
+            enc.contains("\"username\":\"u\""),
+            "username should be plaintext: {}",
+            enc
+        );
+        assert!(
+            enc.contains("enc:v1:"),
+            "password should be encrypted: {}",
+            enc
+        );
         assert!(!enc.contains("s3cr3t"), "plaintext secret leaked: {}", enc);
 
         let dec = decrypt_payload_json(&ws, &enc).unwrap();
@@ -415,7 +442,11 @@ mod tests {
         let ws = temp_ws("env");
         let payload = r#"{"password":"${ENV:PGPASSWORD}"}"#;
         let enc = encrypt_payload_json(&ws, payload).unwrap();
-        assert!(enc.contains("${ENV:PGPASSWORD}"), "placeholder must survive: {}", enc);
+        assert!(
+            enc.contains("${ENV:PGPASSWORD}"),
+            "placeholder must survive: {}",
+            enc
+        );
         let _ = std::fs::remove_dir_all(&ws);
     }
 
@@ -426,7 +457,11 @@ mod tests {
         let enc = encrypt_payload_json(&ws, payload).unwrap();
         assert!(!enc.contains("csecret"), "clientSecret leaked: {}", enc);
         assert!(!enc.contains("atok"), "accessToken leaked: {}", enc);
-        assert!(enc.contains("\"clientId\":\"cid\""), "clientId is not a secret: {}", enc);
+        assert!(
+            enc.contains("\"clientId\":\"cid\""),
+            "clientId is not a secret: {}",
+            enc
+        );
         let _ = std::fs::remove_dir_all(&ws);
     }
 
@@ -466,20 +501,29 @@ mod tests {
         .unwrap();
         write_connection(&ws, "sf-b", &enc);
 
-        let mut sink = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "sf-b"}));
+        let mut sink = sf_node(
+            "snk.salesforce",
+            serde_json::json!({"connectionRef": "sf-b"}),
+        );
         resolve_connection_refs(&ws, std::slice::from_mut(&mut sink)).unwrap();
         let props = sink.data.properties.unwrap();
         assert_eq!(props["authMode"], "bearer");
         assert_eq!(props["instanceUrl"], "https://acme.my.salesforce.com");
         assert_eq!(props["accessToken"], "tok123");
 
-        let mut src = sf_node("src.salesforce", serde_json::json!({"connectionRef": "sf-b"}));
+        let mut src = sf_node(
+            "src.salesforce",
+            serde_json::json!({"connectionRef": "sf-b"}),
+        );
         resolve_connection_refs(&ws, std::slice::from_mut(&mut src)).unwrap();
         let props = src.data.properties.unwrap();
         assert_eq!(props["authType"], "bearer");
         // The REST-shaped source reads the token as authToken.
         assert_eq!(props["authToken"], "tok123");
-        assert!(props.get("instanceUrl").is_none(), "source url is user-authored");
+        assert!(
+            props.get("instanceUrl").is_none(),
+            "source url is user-authored"
+        );
         let _ = std::fs::remove_dir_all(&ws);
     }
 
@@ -492,7 +536,10 @@ mod tests {
         )
         .unwrap();
         write_connection(&ws, "sf-env", &enc);
-        let mut node = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "sf-env"}));
+        let mut node = sf_node(
+            "snk.salesforce",
+            serde_json::json!({"connectionRef": "sf-env"}),
+        );
         resolve_connection_refs(&ws, std::slice::from_mut(&mut node)).unwrap();
         let props = node.data.properties.unwrap();
         // Injected verbatim; the host's ${ENV:} pass runs after resolution.
@@ -503,9 +550,16 @@ mod tests {
     #[test]
     fn missing_connection_errors_with_id() {
         let ws = temp_ws("missing");
-        let mut node = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "nope"}));
+        let mut node = sf_node(
+            "snk.salesforce",
+            serde_json::json!({"connectionRef": "nope"}),
+        );
         let err = resolve_connection_refs(&ws, std::slice::from_mut(&mut node)).unwrap_err();
-        assert!(err.contains("'nope'"), "error should name the connection: {}", err);
+        assert!(
+            err.contains("'nope'"),
+            "error should name the connection: {}",
+            err
+        );
         let _ = std::fs::remove_dir_all(&ws);
     }
 
@@ -522,23 +576,40 @@ mod tests {
         std::fs::remove_file(ws.join(".duckle").join("keys").join("secret.key")).unwrap();
 
         let err = load_connection(&ws, "sf-s").unwrap_err();
-        assert!(err.contains("secret.key"), "run-time load must be strict: {}", err);
+        assert!(
+            err.contains("secret.key"),
+            "run-time load must be strict: {}",
+            err
+        );
         // Editor load stays lenient: ciphertext passes through unchanged.
         let out = decrypt_payload_json(&ws, &enc).unwrap();
-        assert!(out.contains("enc:v1:"), "editor load stays lenient: {}", out);
+        assert!(
+            out.contains("enc:v1:"),
+            "editor load stays lenient: {}",
+            out
+        );
         let _ = std::fs::remove_dir_all(&ws);
     }
 
     #[test]
     fn non_salesforce_nodes_and_refless_nodes_are_untouched() {
         let ws = temp_ws("noop");
-        let mut pg = sf_node("src.postgres", serde_json::json!({"connectionRef": "some-pg"}));
+        let mut pg = sf_node(
+            "src.postgres",
+            serde_json::json!({"connectionRef": "some-pg"}),
+        );
         resolve_connection_refs(&ws, std::slice::from_mut(&mut pg)).unwrap();
-        assert_eq!(pg.data.properties.unwrap(), serde_json::json!({"connectionRef": "some-pg"}));
+        assert_eq!(
+            pg.data.properties.unwrap(),
+            serde_json::json!({"connectionRef": "some-pg"})
+        );
 
         let mut sf = sf_node("snk.salesforce", serde_json::json!({"object": "Account"}));
         resolve_connection_refs(&ws, std::slice::from_mut(&mut sf)).unwrap();
-        assert_eq!(sf.data.properties.unwrap(), serde_json::json!({"object": "Account"}));
+        assert_eq!(
+            sf.data.properties.unwrap(),
+            serde_json::json!({"object": "Account"})
+        );
         let _ = std::fs::remove_dir_all(&ws);
     }
 
@@ -548,7 +619,11 @@ mod tests {
         write_connection(&ws, "pg", r#"{"kind":"postgres","host":"db"}"#);
         let mut node = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "pg"}));
         let err = resolve_connection_refs(&ws, std::slice::from_mut(&mut node)).unwrap_err();
-        assert!(err.contains("kind 'postgres'"), "error should name the kind: {}", err);
+        assert!(
+            err.contains("kind 'postgres'"),
+            "error should name the kind: {}",
+            err
+        );
         let _ = std::fs::remove_dir_all(&ws);
     }
 

--- a/crates/duckle-secrets/src/lib.rs
+++ b/crates/duckle-secrets/src/lib.rs
@@ -1,0 +1,564 @@
+//! Encryption at rest for saved connection secrets, plus run-time resolution
+//! of saved-connection references (#166 stage 2).
+//!
+//! Sensitive connection fields (passwords, tokens, keys) are encrypted with a
+//! per-workspace AES-256-GCM key kept at `<workspace>/.duckle/keys/secret.key`
+//! (owner-only on unix, excluded from version control). The connection JSON in
+//! `<workspace>/connections/` therefore holds ciphertext for those fields, so
+//! the folder is safe to commit or share as long as `.duckle/keys/` is not.
+//! `${...}` placeholders are never encrypted - they resolve from the
+//! environment at run time.
+//!
+//! This crate is the single decrypt path shared by the desktop app and the
+//! headless runner (#166): both call [`resolve_connection_refs`] before their
+//! `${ENV:...}` pass so a node that stores only a `connectionRef` gets its
+//! auth fields injected in memory - the engine stays credential-agnostic and
+//! secrets never land in the pipeline file.
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use base64::Engine;
+use duckle_metadata::PipelineNode;
+use serde_json::Value as JsonValue;
+use std::path::{Path, PathBuf};
+
+pub const ENC_PREFIX: &str = "enc:v1:";
+
+/// Connection-payload fields (by name) that hold a secret and get encrypted.
+pub const SENSITIVE_KEYS: &[&str] = &[
+    "password",
+    "secretKey",
+    "accessKey",
+    "accountKey",
+    "sessionToken",
+    "pat",
+    "token",
+    "apiKey",
+    "passphrase",
+    "secret",
+    // Salesforce OAuth client-credentials + bearer token (#166 stage 2).
+    "clientSecret",
+    "accessToken",
+];
+
+fn key_path(workspace: &Path) -> PathBuf {
+    workspace.join(".duckle").join("keys").join("secret.key")
+}
+
+/// Load the workspace key. With `create`, a fresh random 32-byte key is
+/// generated and persisted on first use; without it, a missing key is an
+/// error (so a workspace shared without the key decrypts to nothing rather
+/// than minting a wrong key).
+pub fn workspace_key(workspace: &Path, create: bool) -> Result<[u8; 32], String> {
+    let path = key_path(workspace);
+    if let Ok(bytes) = std::fs::read(&path) {
+        if bytes.len() == 32 {
+            let mut k = [0u8; 32];
+            k.copy_from_slice(&bytes);
+            return Ok(k);
+        }
+    }
+    if !create {
+        return Err("no workspace key".into());
+    }
+    let mut k = [0u8; 32];
+    getrandom::getrandom(&mut k).map_err(|e| format!("key rng: {}", e))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create keys dir: {}", e))?;
+    }
+    // Create the key file owner-only from the start; writing first and
+    // chmod'ing after left a brief world-readable window (TOCTOU).
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| format!("create key: {}", e))?;
+        f.write_all(&k).map_err(|e| format!("write key: {}", e))?;
+    }
+    #[cfg(not(unix))]
+    std::fs::write(&path, k).map_err(|e| format!("write key: {}", e))?;
+    Ok(k)
+}
+
+pub fn is_encrypted(s: &str) -> bool {
+    s.starts_with(ENC_PREFIX)
+}
+
+/// Encrypt plaintext into an `enc:v1:<base64(nonce || ciphertext)>` token.
+pub fn encrypt_value(key: &[u8; 32], plaintext: &str) -> Result<String, String> {
+    let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| format!("cipher init: {}", e))?;
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::getrandom(&mut nonce_bytes).map_err(|e| format!("nonce rng: {}", e))?;
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_bytes())
+        .map_err(|e| format!("encrypt: {}", e))?;
+    let mut payload = Vec::with_capacity(12 + ciphertext.len());
+    payload.extend_from_slice(&nonce_bytes);
+    payload.extend_from_slice(&ciphertext);
+    Ok(format!(
+        "{}{}",
+        ENC_PREFIX,
+        base64::engine::general_purpose::STANDARD.encode(payload)
+    ))
+}
+
+/// Decrypt an `enc:v1:` token back to plaintext.
+pub fn decrypt_value(key: &[u8; 32], blob: &str) -> Result<String, String> {
+    let b64 = blob.strip_prefix(ENC_PREFIX).ok_or("not an encrypted value")?;
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|e| format!("base64: {}", e))?;
+    if raw.len() < 12 {
+        return Err("ciphertext too short".into());
+    }
+    let (nonce_bytes, ciphertext) = raw.split_at(12);
+    let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| format!("cipher init: {}", e))?;
+    let plain = cipher
+        .decrypt(Nonce::from_slice(nonce_bytes), ciphertext)
+        .map_err(|e| format!("decrypt: {}", e))?;
+    String::from_utf8(plain).map_err(|e| format!("utf8: {}", e))
+}
+
+/// Walk a JSON value, encrypting or decrypting the sensitive string fields in
+/// place. Already-encrypted values and `${...}` placeholders are left alone.
+fn transform(value: &mut JsonValue, key: &[u8; 32], encrypting: bool) -> Result<(), String> {
+    match value {
+        JsonValue::Object(map) => {
+            for (k, v) in map.iter_mut() {
+                if let Some(s) = v.as_str() {
+                    if encrypting {
+                        if SENSITIVE_KEYS.contains(&k.as_str())
+                            && !s.is_empty()
+                            && !is_encrypted(s)
+                            && !s.starts_with("${")
+                        {
+                            // Propagate: never silently leave a secret in
+                            // plaintext (the file is meant to hold ciphertext).
+                            let enc = encrypt_value(key, s)?;
+                            *v = JsonValue::String(enc);
+                        }
+                    } else if is_encrypted(s) {
+                        // Decrypt stays lenient: a missing/legacy value loads
+                        // unchanged rather than failing the read.
+                        if let Ok(dec) = decrypt_value(key, s) {
+                            *v = JsonValue::String(dec);
+                        }
+                    }
+                } else {
+                    transform(v, key, encrypting)?;
+                }
+            }
+        }
+        JsonValue::Array(arr) => {
+            for v in arr.iter_mut() {
+                transform(v, key, encrypting)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Encrypt the sensitive fields of a connection payload JSON before it is
+/// written to disk. Creates the workspace key on first use.
+pub fn encrypt_payload_json(workspace: &Path, payload_json: &str) -> Result<String, String> {
+    let key = workspace_key(workspace, true)?;
+    let mut v: JsonValue =
+        serde_json::from_str(payload_json).map_err(|e| format!("json: {}", e))?;
+    transform(&mut v, &key, true)?;
+    serde_json::to_string(&v).map_err(|e| format!("json: {}", e))
+}
+
+/// Decrypt the sensitive fields of a connection payload JSON after it is read
+/// from disk. If the workspace key is missing, the payload is returned
+/// unchanged so plaintext / legacy values still load. (Editor-facing and
+/// deliberately LENIENT - the run-time path is [`load_connection`], which is
+/// strict, because executing with `enc:v1:` ciphertext as a credential is a
+/// confusing downstream auth failure.)
+pub fn decrypt_payload_json(workspace: &Path, payload_json: &str) -> Result<String, String> {
+    let key = match workspace_key(workspace, false) {
+        Ok(k) => k,
+        Err(_) => return Ok(payload_json.to_string()),
+    };
+    let mut v: JsonValue =
+        serde_json::from_str(payload_json).map_err(|e| format!("json: {}", e))?;
+    transform(&mut v, &key, false)?;
+    serde_json::to_string(&v).map_err(|e| format!("json: {}", e))
+}
+
+/// Any string field anywhere in the value still carrying the `enc:v1:` prefix?
+fn any_encrypted(value: &JsonValue) -> bool {
+    match value {
+        JsonValue::String(s) => is_encrypted(s),
+        JsonValue::Object(map) => map.values().any(any_encrypted),
+        JsonValue::Array(arr) => arr.iter().any(any_encrypted),
+        _ => false,
+    }
+}
+
+/// Run-time load of `<workspace>/connections/<id>.json`, decrypted. STRICT:
+/// a missing file, or an `enc:v1:` field that cannot be decrypted (missing or
+/// wrong workspace key), is an error - unlike the lenient editor-facing
+/// [`decrypt_payload_json`].
+pub fn load_connection(workspace: &Path, id: &str) -> Result<JsonValue, String> {
+    let path = workspace.join("connections").join(format!("{}.json", id));
+    let txt = std::fs::read_to_string(&path).map_err(|e| {
+        format!(
+            "connection '{}' not found under {} ({})",
+            id,
+            workspace.display(),
+            e
+        )
+    })?;
+    let mut v: JsonValue = serde_json::from_str(&txt)
+        .map_err(|e| format!("connection '{}': invalid JSON: {}", id, e))?;
+    if any_encrypted(&v) {
+        let key = workspace_key(workspace, false).map_err(|_| {
+            format!(
+                "connection '{}' holds encrypted fields but {} is missing - \
+                 copy the workspace key or re-enter the secrets",
+                id,
+                key_path(workspace).display()
+            )
+        })?;
+        transform(&mut v, &key, false)?;
+        if any_encrypted(&v) {
+            return Err(format!(
+                "connection '{}' could not be decrypted with the workspace key \
+                 (wrong key?)",
+                id
+            ));
+        }
+    }
+    Ok(v)
+}
+
+/// The payload holds a connection JSON object; read a non-empty string field.
+fn conn_str<'a>(conn: &'a JsonValue, key: &str) -> Option<&'a str> {
+    conn.get(key).and_then(|v| v.as_str()).filter(|s| !s.is_empty())
+}
+
+/// Expand a `connectionRef` on a Salesforce node's properties into the auth
+/// fields the engine reads (#166 stage 2). No-op for every other component or
+/// when no ref is set. The connection WINS over node-level auth props - "ref
+/// set => the saved connection defines auth" keeps rotation in one place and
+/// avoids half-states mixing stale node fields with connection credentials.
+pub fn resolve_connection_ref_props(
+    workspace: &Path,
+    component_id: &str,
+    props: &mut JsonValue,
+) -> Result<(), String> {
+    let is_sink = component_id == "snk.salesforce";
+    let is_source = component_id == "src.salesforce";
+    if !is_sink && !is_source {
+        return Ok(());
+    }
+    let Some(ref_id) = props
+        .get("connectionRef")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+    else {
+        return Ok(());
+    };
+    let conn = load_connection(workspace, &ref_id)?;
+    let kind = conn.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    if kind != "salesforce" {
+        return Err(format!(
+            "{}: connection '{}' is kind '{}', expected a Salesforce connection",
+            component_id, ref_id, kind
+        ));
+    }
+    // Same aliases the engine's salesforce_oauth_from_props accepts.
+    let client_credentials = matches!(
+        conn.get("authMode").and_then(|v| v.as_str()).unwrap_or("bearer"),
+        "clientCredentials" | "client_credentials" | "oauth" | "oauth_client_credentials"
+    );
+    let map = props
+        .as_object_mut()
+        .ok_or_else(|| format!("{}: node properties are not an object", component_id))?;
+    // The sink form keys the mode as `authMode`; the REST-shaped source form
+    // keys it as `authType` (stage 1, 11af9fb).
+    if is_sink {
+        map.insert(
+            "authMode".into(),
+            JsonValue::String(if client_credentials { "clientCredentials" } else { "bearer" }.into()),
+        );
+    } else {
+        map.insert(
+            "authType".into(),
+            JsonValue::String(
+                if client_credentials { "oauth_client_credentials" } else { "bearer" }.into(),
+            ),
+        );
+    }
+    for (conn_key, prop_key) in [
+        ("loginUrl", "loginUrl"),
+        ("clientId", "clientId"),
+        ("clientSecret", "clientSecret"),
+    ] {
+        if let Some(v) = conn_str(&conn, conn_key) {
+            map.insert(prop_key.into(), JsonValue::String(v.into()));
+        }
+    }
+    // instanceUrl feeds the sink endpoint; the source `url` is user-authored
+    // (full query URL), so it is never injected there.
+    if is_sink {
+        if let Some(v) = conn_str(&conn, "instanceUrl") {
+            map.insert("instanceUrl".into(), JsonValue::String(v.into()));
+        }
+    }
+    // Bearer-mode saved connection: the sink reads `accessToken`, the
+    // REST-shaped source reads `authToken` (push_rest_auth).
+    if let Some(v) = conn_str(&conn, "accessToken") {
+        map.insert(
+            if is_sink { "accessToken" } else { "authToken" }.into(),
+            JsonValue::String(v.into()),
+        );
+    }
+    Ok(())
+}
+
+/// Resolve saved-connection references on every Salesforce node in a pipeline
+/// document, in place. Call BEFORE the `${ENV:...}` pass so a connection field
+/// stored as a placeholder still expands afterwards.
+pub fn resolve_connection_refs(
+    workspace: &Path,
+    nodes: &mut [PipelineNode],
+) -> Result<(), String> {
+    for node in nodes.iter_mut() {
+        let Some(component_id) = node.data.component_id.clone() else {
+            continue;
+        };
+        if let Some(props) = node.data.properties.as_mut() {
+            resolve_connection_ref_props(workspace, &component_id, props)?;
+        }
+    }
+    Ok(())
+}
+
+/// Does any Salesforce node in the document carry a `connectionRef`? Lets a
+/// host that has no workspace path fail with a clear message instead of
+/// silently running with unresolved auth.
+pub fn has_connection_refs(nodes: &[PipelineNode]) -> bool {
+    nodes.iter().any(|node| {
+        matches!(
+            node.data.component_id.as_deref(),
+            Some("src.salesforce") | Some("snk.salesforce")
+        ) && node
+            .data
+            .properties
+            .as_ref()
+            .and_then(|p| p.get("connectionRef"))
+            .and_then(|v| v.as_str())
+            .map(|s| !s.is_empty())
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_ws(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("duckle_sec_{}_{}", tag, std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    fn write_connection(ws: &Path, id: &str, payload: &str) {
+        let dir = ws.join("connections");
+        let _ = std::fs::create_dir_all(&dir);
+        std::fs::write(dir.join(format!("{}.json", id)), payload).unwrap();
+    }
+
+    fn sf_node(component_id: &str, props: serde_json::Value) -> PipelineNode {
+        serde_json::from_value(serde_json::json!({
+            "id": "n1",
+            "position": {"x": 0.0, "y": 0.0},
+            "data": {
+                "label": "sf",
+                "componentId": component_id,
+                "properties": props,
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn round_trip_encrypts_only_sensitive_fields() {
+        let ws = temp_ws("rt");
+
+        let payload = r#"{"kind":"postgres","host":"db.local","username":"u","password":"s3cr3t","port":5432}"#;
+        let enc = encrypt_payload_json(&ws, payload).unwrap();
+        // Non-secret fields stay readable; the password becomes ciphertext.
+        assert!(enc.contains("\"host\":\"db.local\""), "host should be plaintext: {}", enc);
+        assert!(enc.contains("\"username\":\"u\""), "username should be plaintext: {}", enc);
+        assert!(enc.contains("enc:v1:"), "password should be encrypted: {}", enc);
+        assert!(!enc.contains("s3cr3t"), "plaintext secret leaked: {}", enc);
+
+        let dec = decrypt_payload_json(&ws, &enc).unwrap();
+        let v: JsonValue = serde_json::from_str(&dec).unwrap();
+        assert_eq!(v["password"], "s3cr3t");
+        assert_eq!(v["host"], "db.local");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn env_placeholders_are_not_encrypted() {
+        let ws = temp_ws("env");
+        let payload = r#"{"password":"${ENV:PGPASSWORD}"}"#;
+        let enc = encrypt_payload_json(&ws, payload).unwrap();
+        assert!(enc.contains("${ENV:PGPASSWORD}"), "placeholder must survive: {}", enc);
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn salesforce_secret_fields_are_encrypted() {
+        let ws = temp_ws("sfenc");
+        let payload = r#"{"kind":"salesforce","authMode":"clientCredentials","clientId":"cid","clientSecret":"csecret","accessToken":"atok"}"#;
+        let enc = encrypt_payload_json(&ws, payload).unwrap();
+        assert!(!enc.contains("csecret"), "clientSecret leaked: {}", enc);
+        assert!(!enc.contains("atok"), "accessToken leaked: {}", enc);
+        assert!(enc.contains("\"clientId\":\"cid\""), "clientId is not a secret: {}", enc);
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn resolve_client_credentials_on_source() {
+        let ws = temp_ws("cc_src");
+        let enc = encrypt_payload_json(
+            &ws,
+            r#"{"kind":"salesforce","authMode":"clientCredentials","loginUrl":"https://acme.my.salesforce.com","clientId":"cid","clientSecret":"csecret"}"#,
+        )
+        .unwrap();
+        write_connection(&ws, "sf-prod", &enc);
+
+        let mut node = sf_node(
+            "src.salesforce",
+            serde_json::json!({"connectionRef": "sf-prod", "authType": "bearer", "url": "https://x/services/data/v60.0/query"}),
+        );
+        resolve_connection_refs(&ws, std::slice::from_mut(&mut node)).unwrap();
+        let props = node.data.properties.unwrap();
+        // Connection wins over the stale node-level bearer mode.
+        assert_eq!(props["authType"], "oauth_client_credentials");
+        assert_eq!(props["loginUrl"], "https://acme.my.salesforce.com");
+        assert_eq!(props["clientId"], "cid");
+        assert_eq!(props["clientSecret"], "csecret");
+        // The user-authored query URL is untouched.
+        assert_eq!(props["url"], "https://x/services/data/v60.0/query");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn resolve_bearer_on_sink_and_source() {
+        let ws = temp_ws("bearer");
+        let enc = encrypt_payload_json(
+            &ws,
+            r#"{"kind":"salesforce","authMode":"bearer","instanceUrl":"https://acme.my.salesforce.com","accessToken":"tok123"}"#,
+        )
+        .unwrap();
+        write_connection(&ws, "sf-b", &enc);
+
+        let mut sink = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "sf-b"}));
+        resolve_connection_refs(&ws, std::slice::from_mut(&mut sink)).unwrap();
+        let props = sink.data.properties.unwrap();
+        assert_eq!(props["authMode"], "bearer");
+        assert_eq!(props["instanceUrl"], "https://acme.my.salesforce.com");
+        assert_eq!(props["accessToken"], "tok123");
+
+        let mut src = sf_node("src.salesforce", serde_json::json!({"connectionRef": "sf-b"}));
+        resolve_connection_refs(&ws, std::slice::from_mut(&mut src)).unwrap();
+        let props = src.data.properties.unwrap();
+        assert_eq!(props["authType"], "bearer");
+        // The REST-shaped source reads the token as authToken.
+        assert_eq!(props["authToken"], "tok123");
+        assert!(props.get("instanceUrl").is_none(), "source url is user-authored");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn env_placeholder_in_connection_survives_resolution() {
+        let ws = temp_ws("cc_env");
+        let enc = encrypt_payload_json(
+            &ws,
+            r#"{"kind":"salesforce","authMode":"clientCredentials","loginUrl":"https://a.my.salesforce.com","clientId":"cid","clientSecret":"${ENV:SF_CLIENT_SECRET}"}"#,
+        )
+        .unwrap();
+        write_connection(&ws, "sf-env", &enc);
+        let mut node = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "sf-env"}));
+        resolve_connection_refs(&ws, std::slice::from_mut(&mut node)).unwrap();
+        let props = node.data.properties.unwrap();
+        // Injected verbatim; the host's ${ENV:} pass runs after resolution.
+        assert_eq!(props["clientSecret"], "${ENV:SF_CLIENT_SECRET}");
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn missing_connection_errors_with_id() {
+        let ws = temp_ws("missing");
+        let mut node = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "nope"}));
+        let err = resolve_connection_refs(&ws, std::slice::from_mut(&mut node)).unwrap_err();
+        assert!(err.contains("'nope'"), "error should name the connection: {}", err);
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn missing_key_is_strict_at_run_time_but_lenient_in_editor() {
+        let ws = temp_ws("strict");
+        let enc = encrypt_payload_json(
+            &ws,
+            r#"{"kind":"salesforce","authMode":"clientCredentials","clientId":"cid","clientSecret":"csecret"}"#,
+        )
+        .unwrap();
+        write_connection(&ws, "sf-s", &enc);
+        // Simulate a workspace copied without .duckle/keys/.
+        std::fs::remove_file(ws.join(".duckle").join("keys").join("secret.key")).unwrap();
+
+        let err = load_connection(&ws, "sf-s").unwrap_err();
+        assert!(err.contains("secret.key"), "run-time load must be strict: {}", err);
+        // Editor load stays lenient: ciphertext passes through unchanged.
+        let out = decrypt_payload_json(&ws, &enc).unwrap();
+        assert!(out.contains("enc:v1:"), "editor load stays lenient: {}", out);
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn non_salesforce_nodes_and_refless_nodes_are_untouched() {
+        let ws = temp_ws("noop");
+        let mut pg = sf_node("src.postgres", serde_json::json!({"connectionRef": "some-pg"}));
+        resolve_connection_refs(&ws, std::slice::from_mut(&mut pg)).unwrap();
+        assert_eq!(pg.data.properties.unwrap(), serde_json::json!({"connectionRef": "some-pg"}));
+
+        let mut sf = sf_node("snk.salesforce", serde_json::json!({"object": "Account"}));
+        resolve_connection_refs(&ws, std::slice::from_mut(&mut sf)).unwrap();
+        assert_eq!(sf.data.properties.unwrap(), serde_json::json!({"object": "Account"}));
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn wrong_kind_connection_errors() {
+        let ws = temp_ws("kind");
+        write_connection(&ws, "pg", r#"{"kind":"postgres","host":"db"}"#);
+        let mut node = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "pg"}));
+        let err = resolve_connection_refs(&ws, std::slice::from_mut(&mut node)).unwrap_err();
+        assert!(err.contains("kind 'postgres'"), "error should name the kind: {}", err);
+        let _ = std::fs::remove_dir_all(&ws);
+    }
+
+    #[test]
+    fn has_connection_refs_detects_salesforce_refs_only() {
+        let sf = sf_node("snk.salesforce", serde_json::json!({"connectionRef": "x"}));
+        let pg = sf_node("src.postgres", serde_json::json!({"connectionRef": "y"}));
+        let bare = sf_node("snk.salesforce", serde_json::json!({"object": "Account"}));
+        assert!(has_connection_refs(&[sf]));
+        assert!(!has_connection_refs(&[pg]));
+        assert!(!has_connection_refs(&[bare]));
+    }
+}

--- a/crates/duckle-secrets/tests/connection_e2e.rs
+++ b/crates/duckle-secrets/tests/connection_e2e.rs
@@ -1,0 +1,202 @@
+//! End-to-end test of #166 stage 2: a pipeline whose Salesforce node holds
+//! ONLY a `connectionRef` runs against a mock org - the saved connection is
+//! encrypted at rest with the workspace key, resolved + decrypted by the
+//! host-side pass, and the engine mints a fresh client-credentials token from
+//! the injected fields. Exercises the exact chain the desktop app and the
+//! headless runner share; the engine itself never touches the keystore.
+//!
+//! Skips (like the engine's own execution tests) unless `DUCKLE_DUCKDB_BIN`
+//! points at a DuckDB CLI - CI's rust matrix sets it.
+
+use std::io::Write;
+use std::path::Path;
+
+use duckle_duckdb_engine::{DuckdbEngine, PipelineDoc};
+use serde_json::{json, Value};
+
+fn engine() -> Option<DuckdbEngine> {
+    let bin = std::env::var("DUCKLE_DUCKDB_BIN").ok()?;
+    let p = std::path::PathBuf::from(bin);
+    p.exists().then(|| DuckdbEngine::new(p))
+}
+
+fn write_file(dir: &Path, name: &str, content: &str) -> String {
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(content.as_bytes()).unwrap();
+    f.flush().unwrap();
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn doc(nodes: Value, edges: Value) -> PipelineDoc {
+    serde_json::from_value(json!({ "nodes": nodes, "edges": edges })).unwrap()
+}
+
+fn node(id: &str, component: &str, props: Value) -> Value {
+    json!({
+        "id": id,
+        "position": { "x": 0, "y": 0 },
+        "data": { "label": id, "componentId": component, "properties": props }
+    })
+}
+
+fn main_edge(id: &str, source: &str, target: &str) -> Value {
+    json!({ "id": id, "source": source, "target": target, "data": { "connectionType": "main" } })
+}
+
+/// Two-request mock org: the token mint, then the sObject Collections POST.
+/// Same shape as the engine tests' `sf_mock_server_oauth`.
+fn sf_mock_server(
+    data_resp: &'static str,
+) -> (
+    u16,
+    std::sync::mpsc::Receiver<Vec<u8>>,
+    std::thread::JoinHandle<()>,
+) {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind sf mock");
+    let port = listener.local_addr().unwrap().port();
+    let handle = std::thread::spawn(move || {
+        for stream in listener.incoming().take(2) {
+            let mut stream = match stream {
+                Ok(s) => s,
+                Err(_) => break,
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_millis(250)))
+                .ok();
+            stream.set_nodelay(true).ok();
+            let mut buf = Vec::with_capacity(8192);
+            let mut chunk = [0u8; 4096];
+            for _ in 0..16 {
+                match stream.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                    Err(_) => break,
+                }
+            }
+            let request_line = String::from_utf8_lossy(&buf)
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            let _ = tx.send(buf);
+            let body = if request_line.contains("oauth2/token") {
+                format!(
+                    r#"{{"access_token":"minted-e2e","instance_url":"http://127.0.0.1:{}","token_type":"Bearer"}}"#,
+                    port
+                )
+            } else {
+                data_resp.to_string()
+            };
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+            let _ = stream.shutdown(std::net::Shutdown::Write);
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    });
+    (port, rx, handle)
+}
+
+#[test]
+fn connection_ref_resolves_decrypts_and_engine_mints() {
+    use std::time::Duration;
+    let Some(engine) = engine() else {
+        eprintln!("skipping: set DUCKLE_DUCKDB_BIN to a duckdb CLI to run");
+        return;
+    };
+    let (port, rx, handle) =
+        sf_mock_server(r#"[{"id":"001000000000001","success":true,"errors":[]}]"#);
+
+    // A workspace holding an ENCRYPTED client-credentials connection.
+    let ws = tempfile::tempdir().unwrap();
+    let login = format!("http://127.0.0.1:{}", port);
+    let enc = duckle_secrets::encrypt_payload_json(
+        ws.path(),
+        &json!({
+            "kind": "salesforce",
+            "authMode": "clientCredentials",
+            "loginUrl": login,
+            "clientId": "e2e-client-id",
+            "clientSecret": "e2e-s3cret",
+        })
+        .to_string(),
+    )
+    .unwrap();
+    assert!(
+        enc.contains("enc:v1:") && !enc.contains("e2e-s3cret"),
+        "clientSecret must be ciphertext at rest: {}",
+        enc
+    );
+    std::fs::create_dir_all(ws.path().join("connections")).unwrap();
+    std::fs::write(ws.path().join("connections").join("sf-e2e.json"), &enc).unwrap();
+
+    // The node carries ONLY the ref - no credential, no URL.
+    let csv = write_file(ws.path(), "in.csv", "Name\nAcme\n");
+    let mut pipeline = doc(
+        json!([
+            node("s", "src.csv", json!({ "path": csv, "hasHeader": true })),
+            node(
+                "f",
+                "snk.salesforce",
+                json!({
+                    "connectionRef": "sf-e2e",
+                    "apiVersion": "v60.0",
+                    "object": "Account",
+                    "operation": "insert"
+                }),
+            ),
+        ]),
+        json!([main_edge("e", "s", "f")]),
+    );
+
+    // Host-side resolution - the same call the desktop app, the scheduler and
+    // the runner make before their env pass.
+    duckle_secrets::resolve_connection_refs(ws.path(), &mut pipeline.nodes).unwrap();
+
+    let r = engine.execute_pipeline_named(&pipeline, "connref-e2e");
+    assert_eq!(r.status, "ok", "ref-only pipeline failed: {:?}", r.error);
+
+    // First request: the client-credentials mint carrying the DECRYPTED secret.
+    let tok_req = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("expected token request");
+    let tok_raw = String::from_utf8_lossy(&tok_req);
+    assert!(
+        tok_raw
+            .lines()
+            .next()
+            .unwrap_or("")
+            .contains("/services/oauth2/token"),
+        "first request should hit the token endpoint"
+    );
+    assert!(
+        tok_raw.contains("client_id=e2e-client-id") && tok_raw.contains("client_secret=e2e-s3cret"),
+        "mint should carry the decrypted connection credentials"
+    );
+
+    // Second request: the Collections POST authed with the minted token.
+    let data_req = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("expected collections request");
+    let _ = handle.join();
+    let data_raw = String::from_utf8_lossy(&data_req);
+    assert!(
+        data_raw.contains("Authorization: Bearer minted-e2e"),
+        "collections POST should use the minted token"
+    );
+    assert!(
+        data_raw.contains(r#""Name":"Acme""#),
+        "collections POST should carry the csv row"
+    );
+}

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 notify = "8"
 notify-debouncer-mini = "0.6"
 duckle-duckdb-engine = { workspace = true }
+duckle-secrets = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -269,6 +269,10 @@ impl Scheduler {
         // Stamp the dynamic date/time builtins (${date}/${datetime}/...) at fire
         // time, so a recurring schedule writes a fresh-dated path on every run.
         duckle_duckdb_engine::context::apply_time_builtins(&mut pipeline);
+        // Expand saved Salesforce connection refs into node auth props (#166
+        // stage 2) BEFORE the env pass, so a connection field stored as
+        // ${ENV:...} still resolves below.
+        duckle_secrets::resolve_connection_refs(&workspace, &mut pipeline.nodes)?;
         // Resolve ${ENV:NAME} from the process environment so scheduled runs see
         // OS env vars just like the headless runner does (issue #137).
         duckle_duckdb_engine::context::apply_env(&mut pipeline);

--- a/docs/salesforce-sink/IMPLEMENTATION.md
+++ b/docs/salesforce-sink/IMPLEMENTATION.md
@@ -88,6 +88,11 @@ migrations work with a connection each side.
 `instanceUrl` doubles as the endpoint base a mock server points at in tests
 (same trick as the Snowflake sink's `endpoint`).
 
+A runnable **live test suite** (insert → retrieve → update with a remapped
+idField → upsert → retrieve → delete, plus auth-matrix and failure-mode
+checks, all against a real org via the headless runner) lives in
+[`live-suite/`](live-suite/README.md) - credential-free, `${ENV:}`-driven.
+
 ## Remaining work
 
 Tier 1 is complete (see Status) and shipped in this PR - sink implemented,

--- a/docs/salesforce-sink/live-suite/.gitignore
+++ b/docs/salesforce-sink/live-suite/.gitignore
@@ -1,0 +1,2 @@
+out/*.csv
+logs/

--- a/docs/salesforce-sink/live-suite/README.md
+++ b/docs/salesforce-sink/live-suite/README.md
@@ -55,8 +55,18 @@ bash run-suite.sh
 ```
 
 Prints a PASS/FAIL line per assertion and exits non-zero on any failure.
-This suite talks to a live org, so it is a manual harness, not part of
-`cargo test`.
+This suite talks to a live org, so it is not part of `cargo test`.
+
+## CI
+
+The `salesforce-integration` job in `.github/workflows/ci.yml` runs this suite,
+but only when opted in: set the repository **variable** `SF_LIVE_TESTS=true`
+and the **secrets** `SF_INSTANCE_URL` / `SF_CLIENT_ID` / `SF_CLIENT_SECRET`.
+Without them the job is skipped (fork PRs never see repository secrets, so it
+cannot leak into external contributions). Mock-level Salesforce coverage —
+including the encrypted-connection → resolution → mint chain
+(`crates/duckle-secrets/tests/connection_e2e.rs`) — runs unconditionally in
+the main rust matrix.
 
 Note: the post-delete emptiness check treats the source's `ok (0 rows)` as the
 clean signal because a query returning 0 records currently materializes a bare

--- a/docs/salesforce-sink/live-suite/README.md
+++ b/docs/salesforce-sink/live-suite/README.md
@@ -1,0 +1,63 @@
+# Salesforce connector live test suite
+
+Runs the full record lifecycle against a **real Salesforce org** through the
+headless runner, exercising the saved-connection resolution added in #166
+stage 2 plus the Tier-1 write paths:
+
+| step | pipeline | proves |
+|---|---|---|
+| s1 | `s1_insert.json` | csv → **insert** via a saved connection (node holds only `connectionRef`) |
+| s2 | `s2_retrieve.json` | `src.salesforce` **query** via the same connection → csv |
+| s3 | `s3_update.json` | **update** with a *remapped* id column (`Id AS RecId`, `idField: RecId`) |
+| s4 | `s4_upsert.json` | **upsert** by `External_ID__c` (overwrites one row, creates another) |
+| s5 | `s5_retrieve2.json` | re-read asserting the update, the overwrite, and the new row |
+| s6 | `s6_delete.json` | **delete** by retrieved Ids; org left clean |
+| t4 | `t4_bearer_inline.json` | inline `${ENV:SF_TOKEN}` Bearer back-compat (no connection) |
+| t6/t7 | `t6_wrongkind.json` / `t7_missingref.json` | wrong-kind / missing `connectionRef` fail with clear errors |
+
+All suite records carry `External_ID__c = SUITE-*`; the delete step and a
+final cleanup remove them, so repeat runs start clean.
+
+## Org prerequisites
+
+1. A Salesforce org you can write test data into (a Developer Edition org or
+   sandbox — the suite creates and deletes a handful of `Account` records).
+2. **`Account.External_ID__c`**: a custom Text field on Account with
+   **External ID** checked (Unique recommended). The upsert step (s4) targets
+   it; without the field, s1/s4 fail with `INVALID_FIELD`.
+3. An **External Client App** (or Connected App) with the OAuth
+   **Client Credentials** flow enabled and a run-as user that can CRUD
+   Accounts.
+
+## Credentials
+
+No credential lives in any file here. `connections/sf-live.json` holds
+`${ENV:...}` placeholders — the host resolves the `connectionRef` first and the
+normal env pass then expands the placeholders (that ordering is part of what
+the suite verifies). Supply:
+
+```bash
+export SF_INSTANCE_URL=https://yourorg.my.salesforce.com   # My Domain base
+export SF_CLIENT_ID=...                                    # consumer key
+export SF_CLIENT_SECRET=...
+```
+
+(In a real workspace you would instead create the connection in the app and
+let the sensitive fields encrypt at rest as `enc:v1:` — the suite uses
+placeholders so the repo carries no key material.)
+
+## Run
+
+```bash
+export DUCKLE_DUCKDB_BIN=/path/to/duckdb          # as for any headless run
+export DUCKLE_RUNNER=/path/to/duckle-runner       # optional; defaults to PATH
+bash run-suite.sh
+```
+
+Prints a PASS/FAIL line per assertion and exits non-zero on any failure.
+This suite talks to a live org, so it is a manual harness, not part of
+`cargo test`.
+
+Note: the post-delete emptiness check treats the source's `ok (0 rows)` as the
+clean signal because a query returning 0 records currently materializes a bare
+`json` relation that breaks the downstream SQL (#170).

--- a/docs/salesforce-sink/live-suite/connections/pg-dummy.json
+++ b/docs/salesforce-sink/live-suite/connections/pg-dummy.json
@@ -1,0 +1,1 @@
+{ "kind": "postgres", "host": "db.example", "username": "u", "password": "not-a-real-password" }

--- a/docs/salesforce-sink/live-suite/connections/sf-live.json
+++ b/docs/salesforce-sink/live-suite/connections/sf-live.json
@@ -1,0 +1,7 @@
+{
+  "kind": "salesforce",
+  "authMode": "clientCredentials",
+  "loginUrl": "${ENV:SF_INSTANCE_URL}",
+  "clientId": "${ENV:SF_CLIENT_ID}",
+  "clientSecret": "${ENV:SF_CLIENT_SECRET}"
+}

--- a/docs/salesforce-sink/live-suite/data/bearer_inline.csv
+++ b/docs/salesforce-sink/live-suite/data/bearer_inline.csv
@@ -1,0 +1,2 @@
+External_ID__c,Name
+SUITE-301,Suite Bearer Inline

--- a/docs/salesforce-sink/live-suite/data/insert.csv
+++ b/docs/salesforce-sink/live-suite/data/insert.csv
@@ -1,0 +1,3 @@
+External_ID__c,Name
+SUITE-101,Suite Insert A
+SUITE-102,Suite Insert B

--- a/docs/salesforce-sink/live-suite/data/upsert.csv
+++ b/docs/salesforce-sink/live-suite/data/upsert.csv
@@ -1,0 +1,3 @@
+External_ID__c,Name
+SUITE-101,Suite Upsert Overwrite A
+SUITE-201,Suite Upsert New

--- a/docs/salesforce-sink/live-suite/run-suite.sh
+++ b/docs/salesforce-sink/live-suite/run-suite.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Live Salesforce connector test suite (#166 stage 2 + Tier-1 regression).
+# Runs the full record lifecycle against a REAL Salesforce org via the
+# headless runner - see README.md for org prerequisites and env vars.
+#
+#   SF_INSTANCE_URL=... SF_CLIENT_ID=... SF_CLIENT_SECRET=... bash run-suite.sh
+#
+# Part 1 - lifecycle, every step through the saved connection (connections/
+# sf-live.json - a connectionRef-resolved connection whose fields are
+# ${ENV:} placeholders, so no credential ever lives in a file):
+#   s1  INSERT    csv -> snk.salesforce insert            (SUITE-101/102)
+#   s2  RETRIEVE  src.salesforce query -> csv
+#   s3  UPDATE    retrieved rows, idField REMAPPED (RecId -> Id)
+#   s4  UPSERT    by External_ID__c: overwrites SUITE-101, creates SUITE-201
+#   s5  RETRIEVE  re-read; assert update + overwrite + new row
+#   s6  DELETE    retrieved Ids; assert org clean
+# Part 2 - auth matrix + failure modes:
+#   t4  inline ${ENV:} bearer upsert (token minted below; back-compat path)
+#   t6  wrong-kind connectionRef (postgres) -> clear error
+#   t7  missing connection id              -> clear error
+#
+# Suite records carry External_ID__c = SUITE-* and s6/final cleanup delete
+# them, so repeat runs start clean.
+set -u
+cd "$(dirname "$0")"
+RUNNER=${DUCKLE_RUNNER:-duckle-runner}
+WS=$(pwd)
+
+: "${SF_INSTANCE_URL:?set SF_INSTANCE_URL (e.g. https://acme.my.salesforce.com)}"
+: "${SF_CLIENT_ID:?set SF_CLIENT_ID (connected-app consumer key)}"
+: "${SF_CLIENT_SECRET:?set SF_CLIENT_SECRET}"
+
+pass=0; fail=0; results=()
+
+check() { # $1 name, $2 expect ("ok" or grep pattern for the error), $3 output
+  local name=$1 expect=$2 out=$3
+  if [ "$expect" = "ok" ]; then
+    if grep -q '^status   : ok' <<<"$out"; then results+=("PASS  $name"); ((pass++)); return 0; fi
+  else
+    if grep -qi "$expect" <<<"$out" && ! grep -q '^status   : ok' <<<"$out"; then results+=("PASS  $name"); ((pass++)); return 0; fi
+  fi
+  results+=("FAIL  $name"); ((fail++)); echo "---- $name output ----"; echo "$out" | tail -8
+}
+
+assert_file() { # $1 name, $2 file, $3 grep pattern
+  if grep -q "$3" "$2" 2>/dev/null; then results+=("PASS  $1"); ((pass++));
+  else results+=("FAIL  $1"); ((fail++)); fi
+}
+
+run_pipe() { "$RUNNER" --pipeline "$1" --workspace "$WS" 2>&1; }
+
+# SOQL right after a write can briefly return stale rows; retry the read.
+retry_read() { # $1 pipeline, $2 out-file, $3 pattern that must appear
+  for attempt in 1 2 3; do
+    rm -f "$2"; run_pipe "$1" >/dev/null 2>&1
+    grep -q "$3" "$2" 2>/dev/null && return 0
+    sleep 5
+  done
+  return 1
+}
+
+# ---- Part 1: the record lifecycle -----------------------------------------
+
+out=$(run_pipe s1_insert.json)
+check "s1 insert csv -> salesforce (saved connection)" ok "$out"
+
+if retry_read s2_retrieve.json out/retrieved.csv 'SUITE-101'; then
+  results+=("PASS  s2 retrieve inserted records"); ((pass++))
+else
+  results+=("FAIL  s2 retrieve inserted records"); ((fail++))
+fi
+assert_file "s2b both inserted rows present" out/retrieved.csv 'Suite Insert B'
+
+out=$(run_pipe s3_update.json)
+check "s3 update retrieved records (remapped idField RecId)" ok "$out"
+if retry_read s5_retrieve2.json out/retrieved2.csv 'Updated Suite Insert B'; then
+  results+=("PASS  s3b update visible on re-read"); ((pass++))
+else
+  results+=("FAIL  s3b update visible on re-read"); ((fail++))
+fi
+
+out=$(run_pipe s4_upsert.json)
+check "s4 upsert by External_ID__c" ok "$out"
+
+if retry_read s5_retrieve2.json out/retrieved2.csv 'Suite Upsert New'; then
+  results+=("PASS  s5 retrieve after upsert (new row present)"); ((pass++))
+else
+  results+=("FAIL  s5 retrieve after upsert (new row present)"); ((fail++))
+fi
+assert_file "s5b upsert overwrote SUITE-101"    out/retrieved2.csv 'Suite Upsert Overwrite A'
+assert_file "s5c s3 update intact on SUITE-102" out/retrieved2.csv 'Updated Suite Insert B'
+
+out=$(run_pipe s6_delete.json)
+check "s6 delete retrieved records" ok "$out"
+# Emptiness check. NOTE: a query returning 0 records currently materializes a
+# bare `json` relation, so the downstream SQL binder-errors (#170) - "n1 ok
+# (0 rows)" in the output is therefore itself the org-clean signal here.
+clean=""
+for attempt in 1 2 3; do
+  sleep 5; rm -f out/retrieved2.csv
+  out=$(run_pipe s5_retrieve2.json)
+  if grep -Eq 'n1 +ok \(0 rows\)' <<<"$out"; then clean=yes; break; fi
+  lines=$(wc -l < out/retrieved2.csv 2>/dev/null || echo 99)
+  [ "$lines" -le 1 ] && { clean=yes; break; }
+done
+if [ -n "$clean" ]; then results+=("PASS  s6b org clean after delete"); ((pass++));
+else results+=("FAIL  s6b org clean after delete"); ((fail++)); fi
+
+# ---- Part 2: auth matrix + failure modes -----------------------------------
+
+# Mint a bearer token from the same client-credentials app so the inline
+# ${ENV:SF_TOKEN} back-compat path is exercised too.
+tok_resp=$(curl -s -X POST "${SF_INSTANCE_URL%/}/services/oauth2/token" \
+  -d grant_type=client_credentials -d "client_id=$SF_CLIENT_ID" -d "client_secret=$SF_CLIENT_SECRET")
+SF_TOKEN=$(sed -n 's/.*"access_token" *: *"\([^"]*\)".*/\1/p' <<<"$tok_resp")
+export SF_TOKEN
+if [ -n "$SF_TOKEN" ]; then
+  out=$(run_pipe t4_bearer_inline.json)
+  check "t4 inline \${ENV:} bearer back-compat" ok "$out"
+else
+  results+=("FAIL  t4 inline bearer (token mint failed: ${tok_resp:0:120})"); ((fail++))
+fi
+
+out=$(run_pipe t6_wrongkind.json)
+check "t6 wrong-kind connectionRef errors" "expected a Salesforce connection" "$out"
+
+out=$(run_pipe t7_missingref.json)
+check "t7 missing connection id errors" "not found" "$out"
+
+# Final cleanup: t4 upserted SUITE-301 after s6's delete; remove whatever
+# SUITE-* remains so repeat runs start clean.
+out=$(run_pipe s6_delete.json)
+check "final cleanup delete" ok "$out"
+
+echo; echo "==== suite results ===="
+printf '%s\n' "${results[@]}"
+echo "==== $pass passed, $fail failed ===="
+exit $((fail > 0))

--- a/docs/salesforce-sink/live-suite/s1_insert.json
+++ b/docs/salesforce-sink/live-suite/s1_insert.json
@@ -1,0 +1,11 @@
+{
+  "name": "s1_insert",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "csv", "componentId": "src.csv",
+        "properties": { "path": "${workspace}/data/insert.csv", "hasHeader": true } } },
+    { "id": "n2", "type": "sink", "position": {"x":300,"y":0},
+      "data": { "label": "Salesforce", "componentId": "snk.salesforce", "properties": { "connectionRef": "sf-live", "apiVersion": "v60.0", "object": "Account", "operation": "insert", "batchSize": 200, "failOnError": true } } }
+  ],
+  "edges": [ { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} } ]
+}

--- a/docs/salesforce-sink/live-suite/s2_retrieve.json
+++ b/docs/salesforce-sink/live-suite/s2_retrieve.json
@@ -1,0 +1,16 @@
+{
+  "name": "s2_retrieve",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "SF query", "componentId": "src.salesforce",
+        "properties": { "connectionRef": "sf-live", "url": "${ENV:SF_INSTANCE_URL}/services/data/v60.0/query?q=SELECT+Id,Name,External_ID__c+FROM+Account+WHERE+External_ID__c+LIKE+%27SUITE-%25%27+ORDER+BY+External_ID__c", "method": "GET", "responsePath": "/records" } } },
+    { "id": "n2", "type": "transform", "position": {"x":300,"y":0},
+      "data": { "label": "shape", "componentId": "code.sql", "properties": { "sql": "SELECT Id, Name, External_ID__c FROM input ORDER BY External_ID__c" } } },
+    { "id": "n3", "type": "sink", "position": {"x":600,"y":0},
+      "data": { "label": "out", "componentId": "snk.csv", "properties": { "path": "${workspace}/out/retrieved.csv", "mode": "overwrite", "hasHeader": true } } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} },
+    { "id": "e2", "source": "n2", "target": "n3", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} }
+  ]
+}

--- a/docs/salesforce-sink/live-suite/s3_update.json
+++ b/docs/salesforce-sink/live-suite/s3_update.json
@@ -1,0 +1,16 @@
+{
+  "name": "s3_update",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "SF query", "componentId": "src.salesforce",
+        "properties": { "connectionRef": "sf-live", "url": "${ENV:SF_INSTANCE_URL}/services/data/v60.0/query?q=SELECT+Id,Name,External_ID__c+FROM+Account+WHERE+External_ID__c+LIKE+%27SUITE-%25%27+ORDER+BY+External_ID__c", "method": "GET", "responsePath": "/records" } } },
+    { "id": "n2", "type": "transform", "position": {"x":300,"y":0},
+      "data": { "label": "shape", "componentId": "code.sql", "properties": { "sql": "SELECT Id AS RecId, 'Updated ' || Name AS Name FROM input" } } },
+    { "id": "n3", "type": "sink", "position": {"x":600,"y":0},
+      "data": { "label": "out", "componentId": "snk.salesforce", "properties": { "connectionRef": "sf-live", "apiVersion": "v60.0", "object": "Account", "operation": "update", "idField": "RecId", "failOnError": true } } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} },
+    { "id": "e2", "source": "n2", "target": "n3", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} }
+  ]
+}

--- a/docs/salesforce-sink/live-suite/s4_upsert.json
+++ b/docs/salesforce-sink/live-suite/s4_upsert.json
@@ -1,0 +1,11 @@
+{
+  "name": "s4_upsert",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "csv", "componentId": "src.csv",
+        "properties": { "path": "${workspace}/data/upsert.csv", "hasHeader": true } } },
+    { "id": "n2", "type": "sink", "position": {"x":300,"y":0},
+      "data": { "label": "Salesforce", "componentId": "snk.salesforce", "properties": { "connectionRef": "sf-live", "apiVersion": "v60.0", "object": "Account", "operation": "upsert", "externalIdField": "External_ID__c", "failOnError": true } } }
+  ],
+  "edges": [ { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} } ]
+}

--- a/docs/salesforce-sink/live-suite/s5_retrieve2.json
+++ b/docs/salesforce-sink/live-suite/s5_retrieve2.json
@@ -1,0 +1,16 @@
+{
+  "name": "s5_retrieve2",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "SF query", "componentId": "src.salesforce",
+        "properties": { "connectionRef": "sf-live", "url": "${ENV:SF_INSTANCE_URL}/services/data/v60.0/query?q=SELECT+Id,Name,External_ID__c+FROM+Account+WHERE+External_ID__c+LIKE+%27SUITE-%25%27+ORDER+BY+External_ID__c", "method": "GET", "responsePath": "/records" } } },
+    { "id": "n2", "type": "transform", "position": {"x":300,"y":0},
+      "data": { "label": "shape", "componentId": "code.sql", "properties": { "sql": "SELECT Id, Name, External_ID__c FROM input ORDER BY External_ID__c" } } },
+    { "id": "n3", "type": "sink", "position": {"x":600,"y":0},
+      "data": { "label": "out", "componentId": "snk.csv", "properties": { "path": "${workspace}/out/retrieved2.csv", "mode": "overwrite", "hasHeader": true } } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} },
+    { "id": "e2", "source": "n2", "target": "n3", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} }
+  ]
+}

--- a/docs/salesforce-sink/live-suite/s6_delete.json
+++ b/docs/salesforce-sink/live-suite/s6_delete.json
@@ -1,0 +1,16 @@
+{
+  "name": "s6_delete",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "SF query", "componentId": "src.salesforce",
+        "properties": { "connectionRef": "sf-live", "url": "${ENV:SF_INSTANCE_URL}/services/data/v60.0/query?q=SELECT+Id,Name,External_ID__c+FROM+Account+WHERE+External_ID__c+LIKE+%27SUITE-%25%27+ORDER+BY+External_ID__c", "method": "GET", "responsePath": "/records" } } },
+    { "id": "n2", "type": "transform", "position": {"x":300,"y":0},
+      "data": { "label": "shape", "componentId": "code.sql", "properties": { "sql": "SELECT Id FROM input" } } },
+    { "id": "n3", "type": "sink", "position": {"x":600,"y":0},
+      "data": { "label": "out", "componentId": "snk.salesforce", "properties": { "connectionRef": "sf-live", "apiVersion": "v60.0", "object": "Account", "operation": "delete", "idField": "Id", "failOnError": true } } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} },
+    { "id": "e2", "source": "n2", "target": "n3", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} }
+  ]
+}

--- a/docs/salesforce-sink/live-suite/t4_bearer_inline.json
+++ b/docs/salesforce-sink/live-suite/t4_bearer_inline.json
@@ -1,0 +1,11 @@
+{
+  "name": "t4_bearer_inline",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "csv", "componentId": "src.csv",
+        "properties": { "path": "${workspace}/data/bearer_inline.csv", "hasHeader": true } } },
+    { "id": "n2", "type": "sink", "position": {"x":300,"y":0},
+      "data": { "label": "Salesforce", "componentId": "snk.salesforce", "properties": { "instanceUrl": "${ENV:SF_INSTANCE_URL}", "accessToken": "${ENV:SF_TOKEN}", "apiVersion": "v60.0", "object": "Account", "operation": "upsert", "externalIdField": "External_ID__c", "failOnError": true } } }
+  ],
+  "edges": [ { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} } ]
+}

--- a/docs/salesforce-sink/live-suite/t6_wrongkind.json
+++ b/docs/salesforce-sink/live-suite/t6_wrongkind.json
@@ -1,0 +1,11 @@
+{
+  "name": "t6_wrongkind",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "csv", "componentId": "src.csv",
+        "properties": { "path": "${workspace}/data/insert.csv", "hasHeader": true } } },
+    { "id": "n2", "type": "sink", "position": {"x":300,"y":0},
+      "data": { "label": "Salesforce", "componentId": "snk.salesforce", "properties": { "connectionRef": "pg-dummy", "apiVersion": "v60.0", "object": "Account", "operation": "insert", "failOnError": true } } }
+  ],
+  "edges": [ { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} } ]
+}

--- a/docs/salesforce-sink/live-suite/t7_missingref.json
+++ b/docs/salesforce-sink/live-suite/t7_missingref.json
@@ -1,0 +1,11 @@
+{
+  "name": "t7_missingref",
+  "nodes": [
+    { "id": "n1", "type": "source", "position": {"x":0,"y":0},
+      "data": { "label": "csv", "componentId": "src.csv",
+        "properties": { "path": "${workspace}/data/insert.csv", "hasHeader": true } } },
+    { "id": "n2", "type": "sink", "position": {"x":300,"y":0},
+      "data": { "label": "Salesforce", "componentId": "snk.salesforce", "properties": { "connectionRef": "does-not-exist", "apiVersion": "v60.0", "object": "Account", "operation": "insert", "failOnError": true } } }
+  ],
+  "edges": [ { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} } ]
+}

--- a/frontend/src/repo-types.ts
+++ b/frontend/src/repo-types.ts
@@ -30,7 +30,8 @@ export type ConnectionKind =
     | 'gcs'
     | 'azure-blob'
     | 'kafka'
-    | 'rest';
+    | 'rest'
+    | 'salesforce';
 
 export type ConnectionPayload = {
     kind: ConnectionKind;
@@ -60,6 +61,15 @@ export type ConnectionPayload = {
     connectTimeout?: number;
     options?: string;
     connParams?: string;
+    // Salesforce OAuth (#166 stage 2). The node stores only a connectionRef;
+    // the host resolves + decrypts these at run time, so the secret never
+    // lands in the pipeline JSON. Field names match what the engine reads.
+    authMode?: string;
+    loginUrl?: string;
+    instanceUrl?: string;
+    clientId?: string;
+    clientSecret?: string;
+    accessToken?: string;
     extra?: Record<string, string>;
     notes?: string;
 };

--- a/frontend/src/workflow-ui/PropertiesPanel.tsx
+++ b/frontend/src/workflow-ui/PropertiesPanel.tsx
@@ -389,6 +389,12 @@ export default function PropertiesPanel({
                     nodeProps: props,
                     onPickConnection: (payload: ConnectionPayload) => {
                         if (!selected) return;
+                        // #166 stage 2: Salesforce connections are ref-only.
+                        // ConnectionRefField already stored the picked id as
+                        // the node's connectionRef; the host resolves +
+                        // decrypts it at RUN time, so credentials are never
+                        // copied into the node props / pipeline JSON.
+                        if (payload.kind === 'salesforce') return;
                         const next = { ...(selected.data.properties ?? {}) };
                         const keys: (keyof ConnectionPayload)[] = [
                             'host',

--- a/frontend/src/workflow-ui/editors/ConnectionEditorModal.tsx
+++ b/frontend/src/workflow-ui/editors/ConnectionEditorModal.tsx
@@ -113,6 +113,13 @@ const CONNECTION_TYPES: ConnectionType[] = [
     },
     { kind: 'kafka', label: 'Kafka', fields: ['brokers', 'username', 'password'] },
     { kind: 'rest', label: 'REST API', fields: ['url'] },
+    {
+        // #166 stage 2: field names match what the engine's Salesforce
+        // connectors read, so run-time resolution injects them verbatim.
+        kind: 'salesforce',
+        label: 'Salesforce',
+        fields: ['authMode', 'loginUrl', 'instanceUrl', 'clientId', 'clientSecret', 'accessToken'],
+    },
 ];
 
 const FIELD_LABELS: Partial<Record<keyof ConnectionPayload, string>> = {
@@ -138,9 +145,21 @@ const FIELD_LABELS: Partial<Record<keyof ConnectionPayload, string>> = {
     connectTimeout: 'Connect timeout (s)',
     options: 'Session options',
     connParams: 'Extra parameters',
+    authMode: 'Auth mode',
+    loginUrl: 'Login URL (Client Credentials)',
+    instanceUrl: 'Instance URL (Bearer mode)',
+    clientId: 'Client ID (Client Credentials)',
+    clientSecret: 'Client secret (Client Credentials)',
+    accessToken: 'Access token (Bearer mode)',
 };
 
-const SECRET_FIELDS = new Set<keyof ConnectionPayload>(['password', 'secretKey', 'accountKey']);
+const SECRET_FIELDS = new Set<keyof ConnectionPayload>([
+    'password',
+    'secretKey',
+    'accountKey',
+    'clientSecret',
+    'accessToken',
+]);
 
 export default function ConnectionEditorModal({ item, onSave, onCancel }: Props) {
     const initial = (item?.payload as ConnectionPayload | undefined) ?? null;
@@ -264,6 +283,26 @@ export default function ConnectionEditorModal({ item, onSave, onCancel }: Props)
                                             <option value="require">require</option>
                                             <option value="verify-ca">verify-ca</option>
                                             <option value="verify-full">verify-full</option>
+                                        </select>
+                                    </div>
+                                );
+                            }
+                            if (field === 'authMode') {
+                                // The values MUST match what the run-time
+                                // resolver maps onto the node's authMode /
+                                // authType props (#166 stage 2).
+                                return (
+                                    <div className="modal-field" key={field}>
+                                        <label className="modal-field-label">
+                                            {FIELD_LABELS[field] ?? field}
+                                        </label>
+                                        <select
+                                            className="modal-input"
+                                            value={(values.authMode as string | undefined) ?? 'bearer'}
+                                            onChange={e => setField('authMode', e.target.value)}
+                                        >
+                                            <option value="bearer">Bearer token (paste / refresh manually)</option>
+                                            <option value="clientCredentials">OAuth 2.0 Client Credentials (mint per run)</option>
                                         </select>
                                     </div>
                                 );

--- a/frontend/src/workflow-ui/fields/manifest-synth.ts
+++ b/frontend/src/workflow-ui/fields/manifest-synth.ts
@@ -207,7 +207,21 @@ const CONNECTION_KIND_FOR: Record<string, string> = {
     'src.elastic': 'elastic', 'snk.elastic': 'elastic',
     'src.opensearch': 'elastic', 'snk.opensearch': 'elastic',
     'src.kafka': 'kafka', 'snk.kafka': 'kafka',
+    'src.salesforce': 'salesforce', 'snk.salesforce': 'salesforce',
 };
+
+// #166 stage 2: unlike every other kind, a Salesforce saved connection is
+// NOT copied into the node - the node keeps only this ref and the host
+// resolves + decrypts it at run time, so the secret never lands in the
+// pipeline JSON. Hence the different description.
+const salesforceConnectionRefField = (): Field => ({
+    key: 'connectionRef',
+    label: 'Saved connection',
+    kind: 'connection-ref',
+    accepts: ['salesforce'],
+    description:
+        'Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; the auth fields below are ignored when set.',
+});
 
 // "Pick a saved connection" dropdown. Placed at the TOP of a credential block
 // so it reads as the primary way to fill the fields below (issue #30).
@@ -1828,6 +1842,7 @@ function synthWarehouseSink(comp: ComponentDef): ComponentManifest {
             {
                 label: 'Salesforce org',
                 fields: [
+                    salesforceConnectionRefField(),
                     {
                         key: 'authMode',
                         label: 'Auth mode',
@@ -2437,6 +2452,7 @@ function synthApiSource(comp: ComponentDef): ComponentManifest {
         {
             label: 'Auth',
             fields: [
+                ...(isSalesforce ? [salesforceConnectionRefField()] : []),
                 {
                     key: 'authType',
                     label: 'Auth type',


### PR DESCRIPTION
Stage 2 of #166, on the agreed boundary: the host resolves saved connections, the engine
stays credential-agnostic, and there is exactly one decrypt path to audit.

## What this does

- **New `crates/duckle-secrets`** (shared by desktop + runner): the AES-256-GCM
  connection-secret code moves out of `apps/desktop/src/secrets.rs` (which becomes a thin
  wrapper — Tauri commands and `workspace_git` callers unchanged). Adds `clientSecret` +
  `accessToken` to `SENSITIVE_KEYS`, a STRICT run-time `load_connection` (missing key or
  undecryptable `enc:v1:` field errors, unlike the lenient editor-facing decrypt), and
  `resolve_connection_refs`, which expands a Salesforce node's `connectionRef` into the auth
  props the stage-1 engine reads.
- **Host wiring** (one call before each `${ENV:}` pass, so a connection field stored as
  `${ENV:...}` still expands): desktop `run_pipeline`/`run_pipeline_partial`, scheduler
  `run_now`, runner `run()`/`run_artifact`, and the web serve run paths (`run_pipeline`,
  `run_stream`, `/api/run`). Scheduler + web serve are beyond what #166 named — without them,
  ref-only pipelines silently break on those surfaces (flagged in the issue).
- **Frontend**: `salesforce` ConnectionKind + editor form (authMode select; clientSecret /
  accessToken masked), `connectionRef` picker on both Salesforce nodes, and — unlike every
  other kind — picking a Salesforce connection does NOT copy fields into the node: the node
  keeps only the ref, so credentials never land in the pipeline JSON.
- **duckle-mcp**: `is_secret_key` gains `clientsecret`/`accesstoken` so `t_create_connection`
  refuses/masks literal Salesforce secrets.

Injection mapping (connection wins over node-level auth props; only non-empty values inject):

| connection field | snk.salesforce | src.salesforce |
|---|---|---|
| `authMode: clientCredentials` | `authMode: clientCredentials` | `authType: oauth_client_credentials` |
| `authMode: bearer` (default) | `authMode: bearer` | `authType: bearer` |
| `loginUrl` / `clientId` / `clientSecret` | same keys | same keys |
| `instanceUrl` | `instanceUrl` | not injected (source `url` is user-authored) |
| `accessToken` | `accessToken` | `authToken` |

## Verification

- 11 unit tests in `duckle-secrets` (round-trip, mapping, strict-vs-lenient decrypt,
  precedence, `${ENV:}` pass-ordering, no-op/wrong-kind/missing cases).
- Engine untouched: `cargo test -p duckle-duckdb-engine` still green (incl. the 6 Salesforce
  tests).
- Live against a real org via the **runnable suite included in this PR**
  (`docs/salesforce-sink/live-suite/` — credential-free, `${ENV:}`-driven): full lifecycle
  insert → retrieve → update with remapped idField → upsert → retrieve → delete through the
  saved connection, plus bearer back-compat and wrong-kind / missing-ref failure modes.
  Needs an org with an `External_ID__c` external-Id field on Account (see its README).
  The same flows were also verified through the web serve path and the desktop app UI.
  (An unrelated pre-existing empty-result quirk found during this testing is filed as #170.)

- CI: the encrypted-connection → resolution → mint chain runs in the rust matrix
  (`crates/duckle-secrets/tests/connection_e2e.rs`, mock org, all three OSes), and an
  **opt-in** `salesforce-integration` job runs the live suite when the repo sets
  `SF_LIVE_TESTS=true` + `SF_INSTANCE_URL`/`SF_CLIENT_ID`/`SF_CLIENT_SECRET` secrets —
  skipped otherwise, including on fork PRs, which never receive repository secrets.

## Known follow-ups (deliberately out of scope)

- `visibleWhen` conditional field visibility (next PR — a ref-only node currently displays the
  inline auth selects at their defaults, e.g. "Bearer token" while actually authenticating via
  Client Credentials; behavior is unaffected, the connection wins at run time).
- Optional `resultsPath` success/error files on the sink (proposed in #166).
- Compile/Plan-tab and source autodetect don't resolve refs yet (`compile_pipeline` takes no
  workspace; two-line fix later, precedent: `pipeline_trust_report`).
- `ctl.foreach`/`ctl.runjob` child pipelines load inside the engine (keystore-free by design) —
  refs there don't resolve; `${ENV:}` remains the answer.
- Web editor shows `enc:v1:` ciphertext for desktop-encrypted workspaces (pre-existing; the web
  *run* path now decrypts server-side).

