### PR TITLE
feat(fe): #166 visibleWhen conditional field visibility; Salesforce forms adopt it

### DIFF
--- a/crates/duckle-mcp/catalog.json
+++ b/crates/duckle-mcp/catalog.json
@@ -30249,7 +30249,7 @@
                 "accepts": [
                   "salesforce"
                 ],
-                "description": "Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; the auth fields below are ignored when set."
+                "description": "Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; inline auth fields hide while one is set."
               },
               {
                 "key": "authMode",
@@ -30266,44 +30266,99 @@
                     "value": "clientCredentials"
                   }
                 ],
-                "description": "Client Credentials mints a fresh short-lived token each run from a connected app, so you stop pasting an expiring token (#166)."
+                "description": "Client Credentials mints a fresh short-lived token each run from a connected app, so you stop pasting an expiring token (#166).",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  }
+                ]
               },
               {
                 "key": "instanceUrl",
-                "label": "Instance URL (Bearer mode)",
+                "label": "Instance URL",
                 "kind": "text",
                 "placeholder": "https://acme.my.salesforce.com",
-                "description": "Org base URL (no trailing slash). Required in Bearer mode; in Client Credentials mode the token response supplies it."
+                "description": "Org base URL (no trailing slash).",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authMode",
+                    "equals": "bearer"
+                  }
+                ]
               },
               {
                 "key": "accessToken",
-                "label": "Access token (Bearer mode)",
+                "label": "Access token",
                 "kind": "text",
                 "secret": true,
                 "placeholder": "${ENV:SF_TOKEN}",
-                "description": "Required in Bearer mode. Use ${ENV:...} so no secret lands in the pipeline JSON."
+                "description": "Use ${ENV:...} so no secret lands in the pipeline JSON.",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authMode",
+                    "equals": "bearer"
+                  }
+                ]
               },
               {
                 "key": "loginUrl",
-                "label": "Login URL (Client Credentials)",
+                "label": "Login URL",
                 "kind": "text",
                 "placeholder": "https://acme.my.salesforce.com",
-                "description": "Your My Domain base. POSTs the client-credentials grant to {loginUrl}/services/oauth2/token. Defaults to Instance URL when blank."
+                "description": "Your My Domain base. POSTs the client-credentials grant to {loginUrl}/services/oauth2/token.",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authMode",
+                    "equals": "clientCredentials"
+                  }
+                ]
               },
               {
                 "key": "clientId",
-                "label": "Client ID (Client Credentials)",
+                "label": "Client ID",
                 "kind": "text",
                 "placeholder": "Connected app consumer key",
-                "description": "Required in Client Credentials mode."
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authMode",
+                    "equals": "clientCredentials"
+                  }
+                ]
               },
               {
                 "key": "clientSecret",
-                "label": "Client secret (Client Credentials)",
+                "label": "Client secret",
                 "kind": "text",
                 "secret": true,
                 "placeholder": "${ENV:SF_CLIENT_SECRET}",
-                "description": "Required in Client Credentials mode. Use ${ENV:...} so no secret lands in the pipeline JSON."
+                "description": "Use ${ENV:...} so no secret lands in the pipeline JSON.",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authMode",
+                    "equals": "clientCredentials"
+                  }
+                ]
               },
               {
                 "key": "apiVersion",
@@ -39193,29 +39248,27 @@
                 "accepts": [
                   "salesforce"
                 ],
-                "description": "Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; the auth fields below are ignored when set."
+                "description": "Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; inline auth fields hide while one is set."
               },
               {
                 "key": "authType",
                 "label": "Auth type",
                 "kind": "select",
-                "defaultValue": "none",
+                "defaultValue": "bearer",
                 "options": [
-                  {
-                    "label": "None",
-                    "value": "none"
-                  },
                   {
                     "label": "Bearer token",
                     "value": "bearer"
                   },
                   {
-                    "label": "API key (header)",
-                    "value": "apikey"
-                  },
-                  {
                     "label": "OAuth 2.0 Client Credentials (mint per run)",
                     "value": "oauth_client_credentials"
+                  }
+                ],
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
                   }
                 ]
               },
@@ -39223,35 +39276,85 @@
                 "key": "authToken",
                 "label": "Token / API key",
                 "kind": "text",
-                "placeholder": "••••••••"
+                "placeholder": "••••••••",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authType",
+                    "equals": "bearer"
+                  }
+                ]
               },
               {
                 "key": "authHeader",
                 "label": "API key header",
                 "kind": "text",
                 "placeholder": "X-API-Key",
-                "description": "Header name for API key auth (e.g. X-API-Key or X-Redmine-API-Key). Used only when Auth type is API key; leave blank to default to X-API-Key."
+                "description": "Header name for API key auth (e.g. X-API-Key or X-Redmine-API-Key). Used only when Auth type is API key; leave blank to default to X-API-Key.",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authType",
+                    "equals": "apikey"
+                  }
+                ]
               },
               {
                 "key": "loginUrl",
-                "label": "Login URL (Client Credentials)",
+                "label": "Login URL",
                 "kind": "text",
                 "placeholder": "https://acme.my.salesforce.com",
-                "description": "Your My Domain base. Mints a fresh token per run at {loginUrl}/services/oauth2/token so you stop pasting an expiring token (#166). Used only when Auth type is OAuth Client Credentials."
+                "description": "Your My Domain base. Mints a fresh token per run at {loginUrl}/services/oauth2/token so you stop pasting an expiring token (#166).",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authType",
+                    "equals": "oauth_client_credentials"
+                  }
+                ]
               },
               {
                 "key": "clientId",
-                "label": "Client ID (Client Credentials)",
+                "label": "Client ID",
                 "kind": "text",
-                "placeholder": "Connected app consumer key"
+                "placeholder": "Connected app consumer key",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authType",
+                    "equals": "oauth_client_credentials"
+                  }
+                ]
               },
               {
                 "key": "clientSecret",
-                "label": "Client secret (Client Credentials)",
+                "label": "Client secret",
                 "kind": "text",
                 "secret": true,
                 "placeholder": "${ENV:SF_CLIENT_SECRET}",
-                "description": "Use ${ENV:...} so no secret lands in the pipeline JSON."
+                "description": "Use ${ENV:...} so no secret lands in the pipeline JSON.",
+                "visibleWhen": [
+                  {
+                    "key": "connectionRef",
+                    "empty": true
+                  },
+                  {
+                    "key": "authType",
+                    "equals": "oauth_client_credentials"
+                  }
+                ]
               }
             ]
           },

--- a/frontend/src/workflow-ui/PropertiesPanel.tsx
+++ b/frontend/src/workflow-ui/PropertiesPanel.tsx
@@ -15,6 +15,7 @@ import SchemaEditor from './SchemaEditor';
 import FieldRenderer from './fields/FieldRenderer';
 import { FieldContext, type ActiveContext } from './fields/FieldContext';
 import { getManifest } from './fields/component-manifests';
+import { isFieldVisible } from './fields/visibility';
 import type { Field } from './fields/types';
 
 type TabId = 'basic' | 'schema' | 'preview' | 'advanced' | 'validation';
@@ -519,7 +520,15 @@ export default function PropertiesPanel({
                             ) : null}
                             {manifest ? (
                                 manifest.sections.map(section => {
-                                    const fields = section.fields.map(field => (
+                                    // visibleWhen (#166 follow-up): drop fields whose
+                                    // conditions don't match the current props, and skip
+                                    // the whole section when nothing remains so no
+                                    // orphan header renders.
+                                    const visibleFields = section.fields.filter(f =>
+                                        isFieldVisible(f, manifest, props),
+                                    );
+                                    if (visibleFields.length === 0) return null;
+                                    const fields = visibleFields.map(field => (
                                         <FieldRenderer
                                             key={field.key}
                                             field={field}
@@ -535,7 +544,7 @@ export default function PropertiesPanel({
                                     // render as a native disclosure so the common case stays
                                     // clean. Open by default if any field already has a value.
                                     if (section.collapsible) {
-                                        const hasValue = section.fields.some(
+                                        const hasValue = visibleFields.some(
                                             f =>
                                                 props[f.key] !== undefined &&
                                                 props[f.key] !== '' &&

--- a/frontend/src/workflow-ui/fields/manifest-synth.ts
+++ b/frontend/src/workflow-ui/fields/manifest-synth.ts
@@ -2,6 +2,7 @@ import { PALETTE, type ComponentDef } from '../palette-data';
 import type {
     ComponentManifest,
     Field,
+    FieldCondition,
     FormSection,
     NodePorts,
     SchemaSource,
@@ -220,8 +221,13 @@ const salesforceConnectionRefField = (): Field => ({
     kind: 'connection-ref',
     accepts: ['salesforce'],
     description:
-        'Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; the auth fields below are ignored when set.',
+        'Pick a saved Salesforce connection (Connections folder). Resolved and decrypted at run time; inline auth fields hide while one is set.',
 });
+
+// visibleWhen building block: show an inline auth field only while NO saved
+// connection is picked (a cleared picker stores '', which counts as empty).
+// Salesforce-only for now; the mechanism is generic (fields/visibility.ts).
+const whenNoConnection = (): FieldCondition => ({ key: 'connectionRef', empty: true });
 
 // "Pick a saved connection" dropdown. Placed at the TOP of a credential block
 // so it reads as the primary way to fill the fields below (issue #30).
@@ -1853,12 +1859,13 @@ function synthWarehouseSink(comp: ComponentDef): ComponentManifest {
                             { label: 'OAuth 2.0 Client Credentials (mint per run)', value: 'clientCredentials' },
                         ],
                         description: 'Client Credentials mints a fresh short-lived token each run from a connected app, so you stop pasting an expiring token (#166).',
+                        visibleWhen: [whenNoConnection()],
                     },
-                    { key: 'instanceUrl', label: 'Instance URL (Bearer mode)', kind: 'text', placeholder: 'https://acme.my.salesforce.com', description: 'Org base URL (no trailing slash). Required in Bearer mode; in Client Credentials mode the token response supplies it.' },
-                    { key: 'accessToken', label: 'Access token (Bearer mode)', kind: 'text', secret: true, placeholder: '${ENV:SF_TOKEN}', description: 'Required in Bearer mode. Use ${ENV:...} so no secret lands in the pipeline JSON.' },
-                    { key: 'loginUrl', label: 'Login URL (Client Credentials)', kind: 'text', placeholder: 'https://acme.my.salesforce.com', description: 'Your My Domain base. POSTs the client-credentials grant to {loginUrl}/services/oauth2/token. Defaults to Instance URL when blank.' },
-                    { key: 'clientId', label: 'Client ID (Client Credentials)', kind: 'text', placeholder: 'Connected app consumer key', description: 'Required in Client Credentials mode.' },
-                    { key: 'clientSecret', label: 'Client secret (Client Credentials)', kind: 'text', secret: true, placeholder: '${ENV:SF_CLIENT_SECRET}', description: 'Required in Client Credentials mode. Use ${ENV:...} so no secret lands in the pipeline JSON.' },
+                    { key: 'instanceUrl', label: 'Instance URL', kind: 'text', placeholder: 'https://acme.my.salesforce.com', description: 'Org base URL (no trailing slash).', visibleWhen: [whenNoConnection(), { key: 'authMode', equals: 'bearer' }] },
+                    { key: 'accessToken', label: 'Access token', kind: 'text', secret: true, placeholder: '${ENV:SF_TOKEN}', description: 'Use ${ENV:...} so no secret lands in the pipeline JSON.', visibleWhen: [whenNoConnection(), { key: 'authMode', equals: 'bearer' }] },
+                    { key: 'loginUrl', label: 'Login URL', kind: 'text', placeholder: 'https://acme.my.salesforce.com', description: 'Your My Domain base. POSTs the client-credentials grant to {loginUrl}/services/oauth2/token.', visibleWhen: [whenNoConnection(), { key: 'authMode', equals: 'clientCredentials' }] },
+                    { key: 'clientId', label: 'Client ID', kind: 'text', placeholder: 'Connected app consumer key', visibleWhen: [whenNoConnection(), { key: 'authMode', equals: 'clientCredentials' }] },
+                    { key: 'clientSecret', label: 'Client secret', kind: 'text', secret: true, placeholder: '${ENV:SF_CLIENT_SECRET}', description: 'Use ${ENV:...} so no secret lands in the pipeline JSON.', visibleWhen: [whenNoConnection(), { key: 'authMode', equals: 'clientCredentials' }] },
                     { key: 'apiVersion', label: 'API version', kind: 'text', defaultValue: 'v60.0' },
                 ],
             },
@@ -2457,23 +2464,49 @@ function synthApiSource(comp: ComponentDef): ComponentManifest {
                     key: 'authType',
                     label: 'Auth type',
                     kind: 'select',
-                    defaultValue: 'none',
-                    options: [
-                        { label: 'None', value: 'none' },
-                        { label: 'Bearer token', value: 'bearer' },
-                        { label: 'API key (header)', value: 'apikey' },
-                        ...(isSalesforce
-                            ? [{ label: 'OAuth 2.0 Client Credentials (mint per run)', value: 'oauth_client_credentials' }]
-                            : []),
-                    ],
+                    // Salesforce only accepts OAuth bearer tokens - no API-key
+                    // header and no anonymous access - so its tile offers just
+                    // Bearer / Client Credentials (default bearer, like the
+                    // sink). Every other REST alias keeps the generic set.
+                    defaultValue: isSalesforce ? 'bearer' : 'none',
+                    options: isSalesforce
+                        ? [
+                              { label: 'Bearer token', value: 'bearer' },
+                              { label: 'OAuth 2.0 Client Credentials (mint per run)', value: 'oauth_client_credentials' },
+                          ]
+                        : [
+                              { label: 'None', value: 'none' },
+                              { label: 'Bearer token', value: 'bearer' },
+                              { label: 'API key (header)', value: 'apikey' },
+                          ],
+                    // visibleWhen stays Salesforce-only for now: on other API
+                    // sources these fields keep rendering unconditionally.
+                    ...(isSalesforce ? { visibleWhen: [whenNoConnection()] } : {}),
                 },
-                { key: 'authToken', label: 'Token / API key', kind: 'text', placeholder: '••••••••' },
-                { key: 'authHeader', label: 'API key header', kind: 'text', placeholder: 'X-API-Key', description: 'Header name for API key auth (e.g. X-API-Key or X-Redmine-API-Key). Used only when Auth type is API key; leave blank to default to X-API-Key.' },
+                {
+                    key: 'authToken',
+                    label: 'Token / API key',
+                    kind: 'text',
+                    placeholder: '••••••••',
+                    ...(isSalesforce
+                        ? { visibleWhen: [whenNoConnection(), { key: 'authType', equals: 'bearer' }] }
+                        : {}),
+                },
+                {
+                    key: 'authHeader',
+                    label: 'API key header',
+                    kind: 'text',
+                    placeholder: 'X-API-Key',
+                    description: 'Header name for API key auth (e.g. X-API-Key or X-Redmine-API-Key). Used only when Auth type is API key; leave blank to default to X-API-Key.',
+                    ...(isSalesforce
+                        ? { visibleWhen: [whenNoConnection(), { key: 'authType', equals: 'apikey' }] }
+                        : {}),
+                },
                 ...(isSalesforce
                     ? [
-                          { key: 'loginUrl', label: 'Login URL (Client Credentials)', kind: 'text' as const, placeholder: 'https://acme.my.salesforce.com', description: 'Your My Domain base. Mints a fresh token per run at {loginUrl}/services/oauth2/token so you stop pasting an expiring token (#166). Used only when Auth type is OAuth Client Credentials.' },
-                          { key: 'clientId', label: 'Client ID (Client Credentials)', kind: 'text' as const, placeholder: 'Connected app consumer key' },
-                          { key: 'clientSecret', label: 'Client secret (Client Credentials)', kind: 'text' as const, secret: true, placeholder: '${ENV:SF_CLIENT_SECRET}', description: 'Use ${ENV:...} so no secret lands in the pipeline JSON.' },
+                          { key: 'loginUrl', label: 'Login URL', kind: 'text' as const, placeholder: 'https://acme.my.salesforce.com', description: 'Your My Domain base. Mints a fresh token per run at {loginUrl}/services/oauth2/token so you stop pasting an expiring token (#166).', visibleWhen: [whenNoConnection(), { key: 'authType', equals: 'oauth_client_credentials' }] },
+                          { key: 'clientId', label: 'Client ID', kind: 'text' as const, placeholder: 'Connected app consumer key', visibleWhen: [whenNoConnection(), { key: 'authType', equals: 'oauth_client_credentials' }] },
+                          { key: 'clientSecret', label: 'Client secret', kind: 'text' as const, secret: true, placeholder: '${ENV:SF_CLIENT_SECRET}', description: 'Use ${ENV:...} so no secret lands in the pipeline JSON.', visibleWhen: [whenNoConnection(), { key: 'authType', equals: 'oauth_client_credentials' }] },
                       ]
                     : []),
             ],

--- a/frontend/src/workflow-ui/fields/types.ts
+++ b/frontend/src/workflow-ui/fields/types.ts
@@ -26,6 +26,20 @@ export type FieldKind =
 
 export type SelectOption = { label: string; value: string };
 
+/**
+ * One visibility condition on another field's EFFECTIVE value (the stored
+ * prop, falling back to that field's defaultValue when unset) - see
+ * visibility.ts (#166 follow-up).
+ */
+export type FieldCondition = {
+    /** Key of the controlling field/prop in the same manifest. */
+    key: string;
+    /** Visible when the effective value equals this (or one of these). */
+    equals?: string | string[];
+    /** Visible when the effective value is unset, null, or ''. */
+    empty?: boolean;
+};
+
 export type Field = {
     key: string;
     label: string;
@@ -42,6 +56,12 @@ export type Field = {
     accepts?: string[];
     /** Render a `text` field as a masked secret input (with show/hide). */
     secret?: boolean;
+    /**
+     * Hide this field unless every condition matches (array = AND). Absent =
+     * always visible. Hidden fields keep their stored prop value - the engine
+     * ignores inapplicable props, so nothing is cleared on hide.
+     */
+    visibleWhen?: FieldCondition | FieldCondition[];
 };
 
 export type FormSection = {

--- a/frontend/src/workflow-ui/fields/visibility.ts
+++ b/frontend/src/workflow-ui/fields/visibility.ts
@@ -1,0 +1,59 @@
+// Conditional field visibility for node property forms (#166 follow-up).
+//
+// A field with `visibleWhen` is shown only while every condition matches the
+// EFFECTIVE value of its controlling field: the stored prop when set, else
+// that field's defaultValue - mirroring how PropertiesPanel feeds values into
+// FieldRenderer, so a fresh node (no props yet) evaluates against the same
+// defaults the user sees selected. The mechanism is generic; any manifest can
+// adopt it by adding `visibleWhen` to a field.
+import type { ComponentManifest, Field, FieldCondition } from './types';
+
+/**
+ * The value a condition should judge: the stored prop when present, else the
+ * defaultValue of the manifest field with that key (scanning every section;
+ * keys are unique per manifest in practice). A key with no matching field
+ * falls back to the raw prop only - safe for props like `connectionRef` that
+ * exist on some component variants and not others.
+ */
+export function effectiveValue(
+    key: string,
+    manifest: ComponentManifest,
+    props: Record<string, unknown>,
+): unknown {
+    if (props[key] !== undefined) return props[key];
+    for (const section of manifest.sections) {
+        const field = section.fields.find(f => f.key === key);
+        if (field) return field.defaultValue;
+    }
+    return undefined;
+}
+
+function matches(
+    cond: FieldCondition,
+    manifest: ComponentManifest,
+    props: Record<string, unknown>,
+): boolean {
+    const value = effectiveValue(cond.key, manifest, props);
+    if (cond.empty !== undefined) {
+        const isEmpty = value === undefined || value === null || value === '';
+        if (isEmpty !== cond.empty) return false;
+    }
+    if (cond.equals !== undefined) {
+        // Selects store strings; String() also copes with bool/number defaults.
+        const s = String(value);
+        const wanted = Array.isArray(cond.equals) ? cond.equals : [cond.equals];
+        if (!wanted.includes(s)) return false;
+    }
+    return true;
+}
+
+/** True when the field has no `visibleWhen`, or every condition matches. */
+export function isFieldVisible(
+    field: Field,
+    manifest: ComponentManifest,
+    props: Record<string, unknown>,
+): boolean {
+    if (!field.visibleWhen) return true;
+    const conds = Array.isArray(field.visibleWhen) ? field.visibleWhen : [field.visibleWhen];
+    return conds.every(c => matches(c, manifest, props));
+}


### PR DESCRIPTION
Follow-up to #166 stage 2 (#171), as proposed on the issue. With saved connections live,
the flat node forms actively mislead: a ref-only Salesforce node renders the inline
`authMode` select at its default, so a node authenticating via Client Credentials
*displays* "Bearer token".

## What this does

- **Generic mechanism** (first data-driven conditional visibility on node forms): `Field`
  gains `visibleWhen?: FieldCondition | FieldCondition[]` with
  `FieldCondition = { key, equals?, empty? }` — array = AND, `equals` array = IN, `empty`
  matches unset/`null`/`''` (a cleared connection picker stores `''`). The predicate
  (`fields/visibility.ts`) judges the controlling field's **effective** value — the stored
  prop, falling back to that field's `defaultValue` — mirroring exactly what the form shows.
  The PropertiesPanel section loop filters through it and skips a section entirely when
  nothing remains (no orphan headers); the collapsible open-if-has-value check scans
  visible fields only.
- **Applied to the Salesforce forms only** (other connectors are untouched; adopting the
  mechanism elsewhere later is just adding `visibleWhen` to a field — e.g. the Snowflake
  pat/jwt fields or the shared REST `authToken` when auth is "None"):
  - `snk.salesforce`: the whole inline auth block hides while a saved connection is
    picked; in inline mode, `instanceUrl`/`accessToken` show only for Bearer,
    `loginUrl`/`clientId`/`clientSecret` only for Client Credentials.
  - `src.salesforce`: same `connectionRef` gating, keyed off `authType`.
- **Salesforce auth-type cleanup** (spotted while testing): the source tile inherited the
  generic REST `None` / `API key (header)` options from the shared `src.rest` form —
  neither can work against Salesforce, whose REST API only accepts OAuth bearer tokens.
  The SF tile now offers Bearer / OAuth Client Credentials with Bearer as the default,
  matching the sink; every other REST alias keeps the full generic set.
- Regenerated `crates/duckle-mcp/catalog.json` (the new key is additive; the MCP side
  reads the catalog as a loose `Value`).

## Notes for review

- Hidden fields keep their stored prop values by design: the engine already ignores
  inapplicable props, and for Salesforce the saved connection overrides them at run time.
  Nothing is cleared on hide, so toggling modes never loses input.
- Pure form-rendering change — no engine or run-path behavior changes.

## Verification

- `npm run build` (tsc + vite) green; catalog regenerated via the export script;
  `cargo test -p duckle-mcp` green (catalog parses/embeds).
- Manual desktop-app pass against a live workspace: sink and source collapse to
  connection-ref + API version when a saved connection is picked and restore on clear;
  Bearer/Client-Credentials toggles swap the right field sets; non-Salesforce REST
  sources (checked HubSpot) render exactly as before; no orphan section headers.
