### PR TITLE
feat(salesforce): #166 resultsPath - Data-Loader-style success/error result files on snk.salesforce

### DIFF
--- a/crates/duckdb-engine/src/connectors.rs
+++ b/crates/duckdb-engine/src/connectors.rs
@@ -538,52 +538,94 @@ impl DuckdbEngine {
             }
         };
 
-        let mut ok_count = 0_usize;
-        let mut fail_count = 0_usize;
-        let mut first_errors: Vec<String> = Vec::new();
-
-        for chunk in rows.chunks(spec.batch_size) {
-            self.check_cancelled()?;
-            let (method, url, body) = build_request(chunk)?;
-            let req = crate::tls::http_agent()
-                .request(&method, &url)
-                .set("Authorization", &auth_header)
-                .set("Content-Type", "application/json")
-                .set("Accept", "application/json");
-            let send = match body {
-                Some(b) => req.send_string(&b),
-                None => req.call(),
-            };
-            match send {
-                Ok(resp) => {
-                    let txt = resp.into_string().unwrap_or_default();
-                    let (ok, fail, errs) = parse_salesforce_results(&txt);
-                    ok_count += ok;
-                    fail_count += fail;
-                    for e in errs {
-                        if first_errors.len() < 5 {
-                            first_errors.push(e);
+        // One SfRecordResult per attempted input row, positionally aligned
+        // with `rows`. The chunk loop lives in a closure so every exit path
+        // (per-record failures, HTTP status, transport error, cancel) funnels
+        // through the single results-file-writing point below - resultsPath
+        // files must land even when the run aborts (#166).
+        let mut record_results: Vec<SfRecordResult> = Vec::with_capacity(rows.len());
+        let run_chunks = |record_results: &mut Vec<SfRecordResult>| -> Result<(), EngineError> {
+            for chunk in rows.chunks(spec.batch_size) {
+                self.check_cancelled()?;
+                let (method, url, body) = build_request(chunk)?;
+                let req = crate::tls::http_agent()
+                    .request(&method, &url)
+                    .set("Authorization", &auth_header)
+                    .set("Content-Type", "application/json")
+                    .set("Accept", "application/json");
+                let send = match body {
+                    Some(b) => req.send_string(&b),
+                    None => req.call(),
+                };
+                match send {
+                    Ok(resp) => {
+                        let txt = resp.into_string().unwrap_or_default();
+                        record_results.extend(parse_salesforce_results(&txt, chunk.len()));
+                    }
+                    Err(ureq::Error::Status(code, response)) => {
+                        let b = response.into_string().unwrap_or_default();
+                        let msg = format!(
+                            "Salesforce HTTP {} from {}: {}",
+                            code,
+                            url,
+                            b.chars().take(300).collect::<String>()
+                        );
+                        // The whole chunk was rejected: give each of its rows
+                        // an error-file entry before aborting.
+                        for _ in 0..chunk.len() {
+                            record_results
+                                .push(SfRecordResult::failure(&format!("HTTP_{}", code), msg.clone()));
                         }
+                        return Err(EngineError::Query(msg));
+                    }
+                    Err(e) => {
+                        let msg = format!("Salesforce HTTP transport to {}: {}", url, e);
+                        for _ in 0..chunk.len() {
+                            record_results
+                                .push(SfRecordResult::failure("HTTP_TRANSPORT", msg.clone()));
+                        }
+                        return Err(EngineError::Query(msg));
                     }
                 }
-                Err(ureq::Error::Status(code, response)) => {
-                    let b = response.into_string().unwrap_or_default();
-                    return Err(EngineError::Query(format!(
-                        "Salesforce HTTP {} from {}: {}",
-                        code,
-                        url,
-                        b.chars().take(300).collect::<String>()
-                    )));
-                }
-                Err(e) => {
-                    return Err(EngineError::Query(format!(
-                        "Salesforce HTTP transport to {}: {}", url, e
-                    )));
+            }
+            Ok(())
+        };
+        let loop_result = run_chunks(&mut record_results);
+
+        let ok_count = record_results.iter().filter(|r| r.success).count();
+        let fail_count = record_results.len() - ok_count;
+        if let Some(dir) = spec.results_path.as_deref() {
+            // Stamp the files with the job + run time so repeat runs
+            // accumulate side by side (Data Loader parity).
+            let stem = format!(
+                "{}_{}_{}",
+                spec.object,
+                spec.operation,
+                chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
+            );
+            let write_result = write_salesforce_results_files(
+                std::path::Path::new(dir),
+                &stem,
+                &rows,
+                &record_results,
+            );
+            // A loop error is the more useful diagnosis, so it wins over a
+            // write error; both failing surfaces the loop error below.
+            if let Err(e) = write_result {
+                if loop_result.is_ok() {
+                    return Err(e);
                 }
             }
         }
+        loop_result?;
 
         if fail_count > 0 && spec.fail_on_error {
+            let first_errors: Vec<String> = record_results
+                .iter()
+                .filter(|r| !r.success)
+                .take(5)
+                .map(SfRecordResult::error_line)
+                .collect();
             return Err(EngineError::Query(format!(
                 "salesforce {} {}: {} succeeded, {} failed. First errors: {}",
                 spec.operation, spec.object, ok_count, fail_count, first_errors.join("; ")
@@ -9378,15 +9420,58 @@ fn salesforce_record_envelope(row: &JsonValue, object: &str) -> JsonValue {
     JsonValue::Object(rec)
 }
 
+/// Per-record outcome of one Salesforce Collections request (#166
+/// resultsPath). `status_code` / `message` stay empty on success; `id` is the
+/// created/updated record Id when Salesforce returned one.
+struct SfRecordResult {
+    success: bool,
+    id: Option<String>,
+    status_code: String,
+    message: String,
+}
+
+impl SfRecordResult {
+    fn failure(status_code: &str, message: String) -> Self {
+        SfRecordResult {
+            success: false,
+            id: None,
+            status_code: status_code.into(),
+            message,
+        }
+    }
+
+    /// "CODE: message" for run feedback, or just the message when there is no
+    /// statusCode (API-level / transport failures).
+    fn error_line(&self) -> String {
+        if self.status_code.is_empty() {
+            self.message.clone()
+        } else {
+            format!("{}: {}", self.status_code, self.message)
+        }
+    }
+}
+
 /// Parse a Salesforce composite/sobjects response body - an array of
-/// `{id, success, errors: [{statusCode, message, fields}]}` - into
-/// (success_count, failure_count, error_messages). A non-array body (e.g. an
-/// API-level error object) counts as a single failure carrying its message so
-/// the caller doesn't silently treat a broken batch as success.
-fn parse_salesforce_results(body: &str) -> (usize, usize, Vec<String>) {
+/// `{id, success, errors: [{statusCode, message, fields}]}` - into one
+/// SfRecordResult per submitted record, positionally aligned with the request
+/// chunk. A non-array / unparseable body (e.g. an API-level error object)
+/// fails all `expected` records with its message, so the caller doesn't
+/// silently treat a broken batch as success; a short array pads the tail with
+/// MISSING_RESULT failures.
+fn parse_salesforce_results(body: &str, expected: usize) -> Vec<SfRecordResult> {
+    let all_failed = |code: &str, msg: String| -> Vec<SfRecordResult> {
+        (0..expected)
+            .map(|_| SfRecordResult::failure(code, msg.clone()))
+            .collect()
+    };
     let parsed: JsonValue = match serde_json::from_str(body) {
         Ok(v) => v,
-        Err(_) => return (0, 0, vec![format!("unparseable response: {}", tail_chars(body, 200))]),
+        Err(_) => {
+            return all_failed(
+                "UNPARSEABLE_RESPONSE",
+                format!("unparseable response: {}", tail_chars(body, 200)),
+            )
+        }
     };
     let arr = match parsed.as_array() {
         Some(a) => a,
@@ -9397,32 +9482,135 @@ fn parse_salesforce_results(body: &str) -> (usize, usize, Vec<String>) {
                 .get("message")
                 .and_then(|m| m.as_str())
                 .unwrap_or("unexpected non-array response");
-            return (0, 1, vec![msg.to_string()]);
+            return all_failed("API_ERROR", msg.to_string());
         }
     };
-    let mut ok = 0_usize;
-    let mut fail = 0_usize;
-    let mut errs = Vec::new();
-    for item in arr {
-        let success = item.get("success").and_then(|s| s.as_bool()).unwrap_or(false);
-        if success {
-            ok += 1;
-        } else {
-            fail += 1;
-            let msg = item
+    let mut out: Vec<SfRecordResult> = arr
+        .iter()
+        .map(|item| {
+            let success = item.get("success").and_then(|s| s.as_bool()).unwrap_or(false);
+            let id = item
+                .get("id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            if success {
+                return SfRecordResult {
+                    success: true,
+                    id,
+                    status_code: String::new(),
+                    message: String::new(),
+                };
+            }
+            let (status_code, message) = item
                 .get("errors")
                 .and_then(|e| e.as_array())
                 .and_then(|a| a.first())
                 .map(|e| {
-                    let code = e.get("statusCode").and_then(|c| c.as_str()).unwrap_or("");
-                    let m = e.get("message").and_then(|m| m.as_str()).unwrap_or("");
-                    format!("{}: {}", code, m)
+                    (
+                        e.get("statusCode").and_then(|c| c.as_str()).unwrap_or("").to_string(),
+                        e.get("message").and_then(|m| m.as_str()).unwrap_or("").to_string(),
+                    )
                 })
-                .unwrap_or_else(|| "unknown error".into());
-            errs.push(msg);
+                .unwrap_or_else(|| (String::new(), "unknown error".into()));
+            SfRecordResult { success: false, id, status_code, message }
+        })
+        .collect();
+    while out.len() < expected {
+        out.push(SfRecordResult::failure(
+            "MISSING_RESULT",
+            "no result entry returned for this record".into(),
+        ));
+    }
+    out
+}
+
+/// RFC 4180 field escaping: quote when the cell contains a comma, quote, CR
+/// or LF; embedded quotes are doubled.
+fn csv_escape(cell: &str) -> String {
+    if cell.contains([',', '"', '\r', '\n']) {
+        format!("\"{}\"", cell.replace('"', "\"\""))
+    } else {
+        cell.to_string()
+    }
+}
+
+/// One input cell for the results CSVs: strings verbatim, null/absent empty,
+/// other scalars and nested values in their compact JSON form (same policy as
+/// the record envelope, which passes nested cells through as-is).
+fn salesforce_result_cell(v: Option<&JsonValue>) -> String {
+    match v {
+        None | Some(JsonValue::Null) => String::new(),
+        Some(JsonValue::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+/// Write the Data-Loader-style result files for a snk.salesforce run (#166
+/// resultsPath): `<stem>_success.csv` = input columns + `sf__Id`,
+/// `<stem>_error.csv` = input columns + `sf__StatusCode` + `sf__Message`.
+/// The caller stamps `stem` with the job details + run time
+/// (`{object}_{operation}_{utc}`) so repeat runs accumulate instead of
+/// overwriting, like Data Loader's per-run files. Both files are always
+/// written, header-only when a side is empty. The header takes the first
+/// row's column order, union-extended with later rows' extras in first-seen
+/// order; input columns that collide with the sf__ report names are skipped
+/// so the report values win. `results` may be shorter than `rows` when the
+/// run aborted mid-loop - unattempted rows land in neither file.
+fn write_salesforce_results_files(
+    dir: &std::path::Path,
+    stem: &str,
+    rows: &[JsonValue],
+    results: &[SfRecordResult],
+) -> Result<(), EngineError> {
+    const REPORT_COLS: [&str; 3] = ["sf__Id", "sf__StatusCode", "sf__Message"];
+    let mut cols: Vec<&str> = Vec::new();
+    for row in rows {
+        if let Some(obj) = row.as_object() {
+            for k in obj.keys() {
+                if REPORT_COLS.contains(&k.as_str()) {
+                    continue;
+                }
+                if !cols.contains(&k.as_str()) {
+                    cols.push(k);
+                }
+            }
         }
     }
-    (ok, fail, errs)
+    let quoted: Vec<String> = cols.iter().map(|c| csv_escape(c)).collect();
+    let header = |extra: &[&str]| -> String {
+        let mut h = quoted.clone();
+        h.extend(extra.iter().map(|s| s.to_string()));
+        h.join(",") + "\n"
+    };
+    let mut success_buf = header(&["sf__Id"]);
+    let mut error_buf = header(&["sf__StatusCode", "sf__Message"]);
+    for (row, res) in rows.iter().zip(results) {
+        let mut cells: Vec<String> = cols
+            .iter()
+            .map(|c| csv_escape(&salesforce_result_cell(row.get(c))))
+            .collect();
+        if res.success {
+            cells.push(csv_escape(res.id.as_deref().unwrap_or("")));
+            success_buf.push_str(&cells.join(","));
+            success_buf.push('\n');
+        } else {
+            cells.push(csv_escape(&res.status_code));
+            cells.push(csv_escape(&res.message));
+            error_buf.push_str(&cells.join(","));
+            error_buf.push('\n');
+        }
+    }
+    std::fs::create_dir_all(dir).map_err(|e| {
+        EngineError::Query(format!("salesforce results: create {}: {}", dir.display(), e))
+    })?;
+    for (suffix, buf) in [("success.csv", success_buf), ("error.csv", error_buf)] {
+        let path = dir.join(format!("{}_{}", stem, suffix));
+        std::fs::write(&path, buf).map_err(|e| {
+            EngineError::Query(format!("salesforce results: write {}: {}", path.display(), e))
+        })?;
+    }
+    Ok(())
 }
 
 /// Build the SELECT expression that casts a Snowflake SQL-API cell (always a
@@ -9672,6 +9860,128 @@ mod connector_helper_tests {
         assert!(!bson_flag_matches(Some(&Bson::Boolean(false)), "true"));
         assert!(!bson_flag_matches(Some(&Bson::String("keep".into())), "delete"));
         assert!(!bson_flag_matches(None, "delete"));
+    }
+}
+
+#[cfg(test)]
+mod salesforce_results_tests {
+    use super::{
+        csv_escape, parse_salesforce_results, salesforce_result_cell,
+        write_salesforce_results_files, SfRecordResult,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn csv_escape_quotes_only_when_needed() {
+        assert_eq!(csv_escape("plain"), "plain");
+        assert_eq!(csv_escape(""), "");
+        assert_eq!(csv_escape("a,b"), "\"a,b\"");
+        assert_eq!(csv_escape("say \"hi\""), "\"say \"\"hi\"\"\"");
+        assert_eq!(csv_escape("line\nbreak"), "\"line\nbreak\"");
+    }
+
+    #[test]
+    fn result_cell_formats_by_json_type() {
+        assert_eq!(salesforce_result_cell(Some(&json!("text"))), "text");
+        assert_eq!(salesforce_result_cell(Some(&json!(null))), "");
+        assert_eq!(salesforce_result_cell(None), "");
+        assert_eq!(salesforce_result_cell(Some(&json!(42))), "42");
+        assert_eq!(salesforce_result_cell(Some(&json!(true))), "true");
+        // Nested values keep their compact JSON form.
+        assert_eq!(salesforce_result_cell(Some(&json!({"a":1}))), "{\"a\":1}");
+    }
+
+    #[test]
+    fn parse_walks_records_positionally() {
+        let body = r#"[
+            {"id":"001A","success":true,"errors":[]},
+            {"success":false,"errors":[{"statusCode":"REQUIRED_FIELD_MISSING","message":"Name missing"}]}
+        ]"#;
+        let r = parse_salesforce_results(body, 2);
+        assert_eq!(r.len(), 2);
+        assert!(r[0].success);
+        assert_eq!(r[0].id.as_deref(), Some("001A"));
+        assert!(!r[1].success);
+        assert_eq!(r[1].status_code, "REQUIRED_FIELD_MISSING");
+        assert_eq!(r[1].message, "Name missing");
+    }
+
+    #[test]
+    fn parse_non_array_fails_every_expected_record() {
+        // An API-level error envelope must not leave later records looking
+        // successful - every submitted record failed.
+        let r = parse_salesforce_results(r#"{"message":"Session expired"}"#, 3);
+        assert_eq!(r.len(), 3);
+        assert!(r.iter().all(|x| !x.success && x.status_code == "API_ERROR"));
+        assert_eq!(r[0].message, "Session expired");
+
+        let u = parse_salesforce_results("<html>gateway error</html>", 2);
+        assert_eq!(u.len(), 2);
+        assert!(u.iter().all(|x| x.status_code == "UNPARSEABLE_RESPONSE"));
+    }
+
+    #[test]
+    fn parse_short_array_pads_missing_results() {
+        let r = parse_salesforce_results(r#"[{"id":"001A","success":true,"errors":[]}]"#, 3);
+        assert_eq!(r.len(), 3);
+        assert!(r[0].success);
+        assert_eq!(r[1].status_code, "MISSING_RESULT");
+        assert_eq!(r[2].status_code, "MISSING_RESULT");
+    }
+
+    #[test]
+    fn results_files_split_rows_and_union_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        // Second row carries an extra column -> header union, first-seen order;
+        // a stray input sf__Id column is skipped so the report value wins.
+        let rows = vec![
+            json!({"Name":"Acme","sf__Id":"stale"}),
+            json!({"Name":"Glo,bex","Region":"EMEA"}),
+        ];
+        let results = vec![
+            SfRecordResult { success: true, id: Some("001A".into()), status_code: String::new(), message: String::new() },
+            SfRecordResult::failure("REQUIRED_FIELD_MISSING", "Industry missing".into()),
+        ];
+        write_salesforce_results_files(dir.path(), "Account_insert_20260715T000000Z", &rows, &results).unwrap();
+        let s = std::fs::read_to_string(dir.path().join("Account_insert_20260715T000000Z_success.csv")).unwrap();
+        let e = std::fs::read_to_string(dir.path().join("Account_insert_20260715T000000Z_error.csv")).unwrap();
+        assert_eq!(s, "Name,Region,sf__Id\nAcme,,001A\n");
+        assert_eq!(
+            e,
+            "Name,Region,sf__StatusCode,sf__Message\n\"Glo,bex\",EMEA,REQUIRED_FIELD_MISSING,Industry missing\n"
+        );
+    }
+
+    #[test]
+    fn results_files_write_header_only_when_side_empty() {
+        // Data Loader parity: both files always exist after a run.
+        let dir = tempfile::tempdir().unwrap();
+        let rows = vec![json!({"Name":"Acme"})];
+        let results = vec![SfRecordResult {
+            success: true,
+            id: Some("001A".into()),
+            status_code: String::new(),
+            message: String::new(),
+        }];
+        write_salesforce_results_files(dir.path(), "Account_insert_20260715T000000Z", &rows, &results).unwrap();
+        let e = std::fs::read_to_string(dir.path().join("Account_insert_20260715T000000Z_error.csv")).unwrap();
+        assert_eq!(e, "Name,sf__StatusCode,sf__Message\n");
+    }
+
+    #[test]
+    fn results_files_skip_unattempted_rows() {
+        // results shorter than rows (a chunk aborted the run): the tail rows
+        // land in neither file.
+        let dir = tempfile::tempdir().unwrap();
+        let rows = vec![json!({"Name":"Acme"}), json!({"Name":"Globex"})];
+        let results = vec![SfRecordResult::failure("HTTP_401", "Salesforce HTTP 401".into())];
+        write_salesforce_results_files(dir.path(), "Account_insert_20260715T000000Z", &rows, &results).unwrap();
+        let s = std::fs::read_to_string(dir.path().join("Account_insert_20260715T000000Z_success.csv")).unwrap();
+        let e = std::fs::read_to_string(dir.path().join("Account_insert_20260715T000000Z_error.csv")).unwrap();
+        assert_eq!(s, "Name,sf__Id\n");
+        assert_eq!(e.matches('\n').count(), 2, "header + exactly one error row: {}", e);
+        assert!(e.contains("Acme,HTTP_401,"));
+        assert!(!e.contains("Globex"));
     }
 }
 

--- a/crates/duckdb-engine/src/plan/mod.rs
+++ b/crates/duckdb-engine/src/plan/mod.rs
@@ -1770,6 +1770,7 @@ fn build_stage(
             fail_on_error: props.get("failOnError").and_then(|v| v.as_bool()).unwrap_or(true),
             api,
             oauth,
+            results_path: string_prop(&props, "resultsPath").filter(|s| !s.is_empty()),
         });
         (String::new(), StageKind::Sink, Some(from_view.to_string()))
     } else if component_id == "snk.elastic" || component_id == "snk.opensearch" {

--- a/crates/duckdb-engine/src/plan/specs.rs
+++ b/crates/duckdb-engine/src/plan/specs.rs
@@ -1479,6 +1479,16 @@ pub struct SalesforceSinkSpec {
     /// `instance_url` from the token response overrides `instance_url` when the
     /// latter is empty.
     pub oauth: Option<SalesforceOAuth>,
+    /// When set, a directory that receives Data-Loader-style per-record result
+    /// files after every run (#166), stamped with the job + run time so runs
+    /// accumulate: `{object}_{operation}_{utc}_success.csv` (input columns +
+    /// `sf__Id`) and `..._error.csv` (input columns + `sf__StatusCode` +
+    /// `sf__Message`). Both files are always written - header-only when a side
+    /// is empty - and they land even when the stage errors (failOnError or an
+    /// HTTP failure), so the reject stream survives an aborted run. Records in
+    /// chunks that were never attempted (a preceding chunk aborted the run)
+    /// appear in neither file.
+    pub results_path: Option<String>,
 }
 
 /// snk.execsource "Execute in Source" (#115 in-database processing v1b): run a

--- a/crates/duckdb-engine/tests/execution.rs
+++ b/crates/duckdb-engine/tests/execution.rs
@@ -11558,6 +11558,165 @@ fn snk_salesforce_record_error_fails_run() {
 }
 
 #[test]
+fn snk_salesforce_results_files_written() {
+    // #166 resultsPath: a mixed batch splits into Data-Loader-style
+    // success.csv (input cols + sf__Id) and error.csv (input cols +
+    // sf__StatusCode + sf__Message) under the configured directory.
+    use std::time::Duration;
+    let engine = engine_or_skip!();
+    let (port, rx, handle) = sf_mock_server(
+        r#"[{"id":"001000000000001","success":true,"errors":[]},{"success":false,"errors":[{"statusCode":"REQUIRED_FIELD_MISSING","message":"Required fields are missing: [Industry]"}]},{"id":"001000000000003","success":true,"errors":[]}]"#,
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let csv = write_file(tmp.path(), "in.csv", "Name\nAcme\nGlobex\nInitech\n");
+    let results_dir = out_path(tmp.path(), "sf-results");
+    let instance = format!("http://127.0.0.1:{}", port);
+    let r = engine.execute_pipeline(&doc(
+        json!([
+            node("s", "src.csv", json!({ "path": csv, "hasHeader": true })),
+            node(
+                "f",
+                "snk.salesforce",
+                json!({
+                    "instanceUrl": instance,
+                    "accessToken": "tok-123",
+                    "object": "Account",
+                    "operation": "insert",
+                    "failOnError": false,
+                    "resultsPath": results_dir
+                }),
+            ),
+        ]),
+        json!([main_edge("e", "s", "f")]),
+    ));
+    let _ = rx.recv_timeout(Duration::from_secs(5));
+    let _ = handle.join();
+    assert_eq!(r.status, "ok", "failOnError=false run failed: {:?}", r.error);
+
+    // Filenames are stamped with the job + run time so repeat runs
+    // accumulate: {object}_{operation}_{utc}_success.csv / _error.csv.
+    let names: Vec<String> = std::fs::read_dir(tmp.path().join("sf-results"))
+        .expect("results dir exists")
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(names.len(), 2, "one success + one error file: {:?}", names);
+    assert!(
+        names.iter().all(|n| n.starts_with("Account_insert_"))
+            && names.iter().any(|n| n.ends_with("_success.csv"))
+            && names.iter().any(|n| n.ends_with("_error.csv")),
+        "stamped filenames expected: {:?}",
+        names
+    );
+
+    let success = format!("read_csv_auto('{}/*_success.csv')", results_dir);
+    let error = format!("read_csv_auto('{}/*_error.csv')", results_dir);
+    assert_eq!(count(&success), 2, "2 records succeeded");
+    assert_eq!(
+        scalar_string(&format!("SELECT sf__Id FROM {} WHERE Name = 'Acme'", success)),
+        "001000000000001",
+        "success.csv should carry the created record Id"
+    );
+    assert_eq!(count(&error), 1, "1 record failed");
+    assert_eq!(
+        scalar_string(&format!("SELECT Name FROM {}", error)),
+        "Globex",
+        "error.csv should carry the failing input row"
+    );
+    assert_eq!(
+        scalar_string(&format!("SELECT sf__StatusCode FROM {}", error)),
+        "REQUIRED_FIELD_MISSING"
+    );
+    assert!(
+        scalar_string(&format!("SELECT sf__Message FROM {}", error)).contains("Industry"),
+        "error.csv should carry the Salesforce message"
+    );
+}
+
+#[test]
+fn snk_salesforce_results_files_written_on_fail() {
+    // The core resultsPath guarantee: files land even when failOnError (the
+    // default) aborts the stage, so the reject stream survives a failed run.
+    use std::time::Duration;
+    let engine = engine_or_skip!();
+    let (port, rx, handle) = sf_mock_server(
+        r#"[{"success":false,"errors":[{"statusCode":"REQUIRED_FIELD_MISSING","message":"Required fields are missing: [Name]"}]},{"id":"001000000000002","success":true,"errors":[]}]"#,
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let csv = write_file(tmp.path(), "in.csv", "Name\nAcme\nGlobex\n");
+    let results_dir = out_path(tmp.path(), "sf-results");
+    let instance = format!("http://127.0.0.1:{}", port);
+    let r = engine.execute_pipeline(&doc(
+        json!([
+            node("s", "src.csv", json!({ "path": csv, "hasHeader": true })),
+            node(
+                "f",
+                "snk.salesforce",
+                json!({
+                    "instanceUrl": instance,
+                    "accessToken": "tok-123",
+                    "object": "Account",
+                    "operation": "insert",
+                    "resultsPath": results_dir
+                }),
+            ),
+        ]),
+        json!([main_edge("e", "s", "f")]),
+    ));
+    let _ = rx.recv_timeout(Duration::from_secs(5));
+    let _ = handle.join();
+    assert_eq!(r.status, "error", "failOnError default must abort the run");
+
+    let success = format!("read_csv_auto('{}/*_success.csv')", results_dir);
+    let error = format!("read_csv_auto('{}/*_error.csv')", results_dir);
+    assert_eq!(count(&success), 1, "success.csv written despite the abort");
+    assert_eq!(count(&error), 1, "error.csv written despite the abort");
+    assert_eq!(
+        scalar_string(&format!("SELECT sf__StatusCode FROM {}", error)),
+        "REQUIRED_FIELD_MISSING"
+    );
+}
+
+#[test]
+fn snk_salesforce_no_results_path_writes_nothing() {
+    use std::time::Duration;
+    let engine = engine_or_skip!();
+    let (port, rx, handle) = sf_mock_server(
+        r#"[{"id":"001000000000001","success":true,"errors":[]},{"id":"001000000000002","success":true,"errors":[]}]"#,
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    let csv = write_file(tmp.path(), "in.csv", "Name\nAcme\nGlobex\n");
+    let instance = format!("http://127.0.0.1:{}", port);
+    let r = engine.execute_pipeline(&doc(
+        json!([
+            node("s", "src.csv", json!({ "path": csv, "hasHeader": true })),
+            node(
+                "f",
+                "snk.salesforce",
+                json!({
+                    "instanceUrl": instance,
+                    "accessToken": "tok-123",
+                    "object": "Account",
+                    "operation": "insert"
+                }),
+            ),
+        ]),
+        json!([main_edge("e", "s", "f")]),
+    ));
+    let _ = rx.recv_timeout(Duration::from_secs(5));
+    let _ = handle.join();
+    assert_eq!(r.status, "ok", "run failed: {:?}", r.error);
+    assert!(
+        !tmp.path().join("sf-results").exists()
+            && !tmp.path().join("success.csv").exists()
+            && !tmp.path().join("error.csv").exists(),
+        "no result files without resultsPath"
+    );
+}
+
+#[test]
 fn snk_salesforce_update_remaps_idfield() {
     // A non-default idField ("CrmId") must be mapped onto the record's `Id`
     // key; sObject Collections update rejects records with no Id.

--- a/crates/duckle-mcp/catalog.json
+++ b/crates/duckle-mcp/catalog.json
@@ -30861,7 +30861,14 @@
                 "label": "Fail the run on record errors",
                 "kind": "bool",
                 "defaultValue": true,
-                "description": "When off, per-record errors are logged and the stage continues (a reject output stream is planned)."
+                "description": "When off, per-record errors are logged and the stage continues. Set Results directory to capture per-record outcomes either way."
+              },
+              {
+                "key": "resultsPath",
+                "label": "Results directory",
+                "kind": "text",
+                "placeholder": "${workspace}/out/sf-results",
+                "description": "When set, writes Data-Loader-style per-run result files, stamped {object}_{operation}_{runtime}: ..._success.csv (input columns + sf__Id) and ..._error.csv (+ sf__StatusCode, sf__Message) - written even when the run fails."
               }
             ]
           }

--- a/docs/salesforce-sink/IMPLEMENTATION.md
+++ b/docs/salesforce-sink/IMPLEMENTATION.md
@@ -76,7 +76,41 @@ mode - use `${ENV:SF_TOKEN}`), `loginUrl` / `clientId` / `clientSecret`
 `object` (required), `operation` (insert|update|upsert|delete),
 `externalIdField` (required for upsert), `idField` (default `Id`, for
 update/delete), `api` (collections|bulk), `batchSize` (clamped to 200),
-`allOrNone` (default false), `failOnError` (default true).
+`allOrNone` (default false), `failOnError` (default true),
+`resultsPath` (optional directory - #166).
+
+### Per-record result files (`resultsPath`)
+
+When `resultsPath` is set, every run writes two Data-Loader-style files into
+that directory (created if missing), stamped with the job and UTC run time so
+repeat runs accumulate side by side instead of overwriting:
+
+- `{object}_{operation}_{yyyymmddThhmmssZ}_success.csv` - input columns +
+  `sf__Id` (the created/updated record Id)
+- `{object}_{operation}_{yyyymmddThhmmssZ}_error.csv` - input columns +
+  `sf__StatusCode` + `sf__Message`
+
+(e.g. `Account_insert_20260715T033801Z_success.csv`)
+
+Semantics:
+
+- **Both files are always written**, header-only when a side is empty (Data
+  Loader parity), and they land **even when the stage errors** - `failOnError`
+  aborts, an HTTP error, a cancel - so the reject stream survives a failed run.
+- Rows appear positionally: the header is the first row's column order,
+  union-extended with later rows' extra columns in first-seen order; input
+  columns named `sf__Id`/`sf__StatusCode`/`sf__Message` are skipped so the
+  report values win.
+- A chunk rejected wholesale (HTTP status/transport error) fails every one of
+  its rows with `HTTP_<code>` / `HTTP_TRANSPORT`; an API-level error body
+  fails the whole chunk with `API_ERROR` (previously such a body counted as a
+  single failure regardless of chunk size). Chunks never attempted because an
+  earlier chunk aborted the run appear in **neither** file.
+- Cells: strings verbatim, nulls empty, other scalars/nested values in compact
+  JSON form; RFC 4180 quoting.
+
+`resultsPath` resolves `${workspace}`/`${ENV:...}` on the host like other path
+props (e.g. `${workspace}/out/sf-results`).
 
 In Client-Credentials mode the engine POSTs `grant_type=client_credentials` to
 `{loginUrl}/services/oauth2/token` once per run and uses the returned
@@ -101,7 +135,7 @@ Sinks table, `docs/roadmap.md`, `CONTRIBUTING.md`). What's left is follow-up:
 
 1. **Tier 2 - Bulk API 2.0** - new `RuntimeSpec` path with a poll loop (create → upload CSV → close → poll → fetch success/failed results); the `SalesforceWriteApi::Bulk` variant is already reserved and rejected at plan time.
 2. **Salesforce auth: OAuth Client-Credentials** - *shipped (#166).* Both `src.salesforce` and this sink now offer a client-credentials `authMode`: the engine mints a fresh short-lived token per run from `clientId`/`clientSecret`/`loginUrl` (`{loginUrl}/services/oauth2/token`) instead of a pasted ~2h Bearer token. Follow-ups: (a) a first-class *saved, encrypted* Salesforce Connection kind so the node stores a connection-ref rather than inline `${ENV:}` credentials (Duckle already has `create_connection`/`list_connections`); (b) JWT-bearer + 401-retry/refresh.
-3. **Tier 3** - reject/error output stream, parent→child ID remapping, external-Id relationship resolution, compound fields (Address/Location), API-limit retry/backoff.
+3. **Tier 3** - reject/error output stream (*partially shipped as `resultsPath` success/error files - #166; a first-class reject output port remains*), parent→child ID remapping, external-Id relationship resolution, compound fields (Address/Location), API-limit retry/backoff.
 
 ## Contribution checklist (per CONTRIBUTING.md)
 

--- a/docs/salesforce-sink/live-suite/.gitignore
+++ b/docs/salesforce-sink/live-suite/.gitignore
@@ -1,2 +1,3 @@
 out/*.csv
 logs/
+out/sf-results/

--- a/docs/salesforce-sink/live-suite/run-suite.sh
+++ b/docs/salesforce-sink/live-suite/run-suite.sh
@@ -61,8 +61,25 @@ retry_read() { # $1 pipeline, $2 out-file, $3 pattern that must appear
 
 # ---- Part 1: the record lifecycle -----------------------------------------
 
+rm -rf out/sf-results
 out=$(run_pipe s1_insert.json)
 check "s1 insert csv -> salesforce (saved connection)" ok "$out"
+# #166 resultsPath: s1 also writes Data-Loader-style per-record result files,
+# stamped {object}_{operation}_{utc} so repeat runs accumulate.
+s_file=$(ls out/sf-results/Account_insert_*_success.csv 2>/dev/null | head -1)
+s_rows=$(( $( [ -n "$s_file" ] && wc -l < "$s_file" || echo 0 ) - 1 ))
+if [ "$s_rows" -eq 2 ] && grep -q 'sf__Id' "$s_file" 2>/dev/null; then
+  results+=("PASS  s1b stamped success csv: 2 rows + sf__Id column"); ((pass++))
+else
+  results+=("FAIL  s1b stamped success csv: 2 rows + sf__Id column"); ((fail++))
+fi
+e_file=$(ls out/sf-results/Account_insert_*_error.csv 2>/dev/null | head -1)
+e_lines=$(( $( [ -n "$e_file" ] && wc -l < "$e_file" || echo 0 ) ))
+if [ "$e_lines" -eq 1 ]; then
+  results+=("PASS  s1c stamped error csv written header-only"); ((pass++))
+else
+  results+=("FAIL  s1c stamped error csv written header-only"); ((fail++))
+fi
 
 if retry_read s2_retrieve.json out/retrieved.csv 'SUITE-101'; then
   results+=("PASS  s2 retrieve inserted records"); ((pass++))
@@ -92,15 +109,13 @@ assert_file "s5c s3 update intact on SUITE-102" out/retrieved2.csv 'Updated Suit
 
 out=$(run_pipe s6_delete.json)
 check "s6 delete retrieved records" ok "$out"
-# Emptiness check. NOTE: a query returning 0 records currently materializes a
-# bare `json` relation, so the downstream SQL binder-errors (#170) - "n1 ok
-# (0 rows)" in the output is therefore itself the org-clean signal here.
+# Emptiness check: s5's source declares a schema, so a 0-record query flows
+# through as a typed empty relation (#170) and the csv lands header-only.
 clean=""
 for attempt in 1 2 3; do
   sleep 5; rm -f out/retrieved2.csv
   out=$(run_pipe s5_retrieve2.json)
-  if grep -Eq 'n1 +ok \(0 rows\)' <<<"$out"; then clean=yes; break; fi
-  lines=$(wc -l < out/retrieved2.csv 2>/dev/null || echo 99)
+  if [ -f out/retrieved2.csv ]; then lines=$(wc -l < out/retrieved2.csv); else lines=99; fi
   [ "$lines" -le 1 ] && { clean=yes; break; }
 done
 if [ -n "$clean" ]; then results+=("PASS  s6b org clean after delete"); ((pass++));

--- a/docs/salesforce-sink/live-suite/s1_insert.json
+++ b/docs/salesforce-sink/live-suite/s1_insert.json
@@ -5,7 +5,7 @@
       "data": { "label": "csv", "componentId": "src.csv",
         "properties": { "path": "${workspace}/data/insert.csv", "hasHeader": true } } },
     { "id": "n2", "type": "sink", "position": {"x":300,"y":0},
-      "data": { "label": "Salesforce", "componentId": "snk.salesforce", "properties": { "connectionRef": "sf-live", "apiVersion": "v60.0", "object": "Account", "operation": "insert", "batchSize": 200, "failOnError": true } } }
+      "data": { "label": "Salesforce", "componentId": "snk.salesforce", "properties": { "connectionRef": "sf-live", "apiVersion": "v60.0", "object": "Account", "operation": "insert", "batchSize": 200, "failOnError": true, "resultsPath": "${workspace}/out/sf-results" } } }
   ],
   "edges": [ { "id": "e1", "source": "n1", "target": "n2", "sourceHandle": "main", "targetHandle": "main", "data": {"connectionType": "main"} } ]
 }

--- a/docs/salesforce-sink/live-suite/s5_retrieve2.json
+++ b/docs/salesforce-sink/live-suite/s5_retrieve2.json
@@ -3,7 +3,12 @@
   "nodes": [
     { "id": "n1", "type": "source", "position": {"x":0,"y":0},
       "data": { "label": "SF query", "componentId": "src.salesforce",
-        "properties": { "connectionRef": "sf-live", "url": "${ENV:SF_INSTANCE_URL}/services/data/v60.0/query?q=SELECT+Id,Name,External_ID__c+FROM+Account+WHERE+External_ID__c+LIKE+%27SUITE-%25%27+ORDER+BY+External_ID__c", "method": "GET", "responsePath": "/records" } } },
+        "properties": { "connectionRef": "sf-live", "url": "${ENV:SF_INSTANCE_URL}/services/data/v60.0/query?q=SELECT+Id,Name,External_ID__c+FROM+Account+WHERE+External_ID__c+LIKE+%27SUITE-%25%27+ORDER+BY+External_ID__c", "method": "GET", "responsePath": "/records" },
+        "schema": [
+          { "name": "Id", "type": "string" },
+          { "name": "Name", "type": "string" },
+          { "name": "External_ID__c", "type": "string" }
+        ] } },
     { "id": "n2", "type": "transform", "position": {"x":300,"y":0},
       "data": { "label": "shape", "componentId": "code.sql", "properties": { "sql": "SELECT Id, Name, External_ID__c FROM input ORDER BY External_ID__c" } } },
     { "id": "n3", "type": "sink", "position": {"x":600,"y":0},

--- a/frontend/src/workflow-ui/fields/manifest-synth.ts
+++ b/frontend/src/workflow-ui/fields/manifest-synth.ts
@@ -1906,7 +1906,8 @@ function synthWarehouseSink(comp: ComponentDef): ComponentManifest {
                         description: 'Salesforce caps sObject Collections at 200; higher values are clamped.',
                     },
                     { key: 'allOrNone', label: 'All-or-none', kind: 'bool', defaultValue: false, description: 'When on, any failing record rolls back the whole request (Salesforce-side).' },
-                    { key: 'failOnError', label: 'Fail the run on record errors', kind: 'bool', defaultValue: true, description: 'When off, per-record errors are logged and the stage continues (a reject output stream is planned).' },
+                    { key: 'failOnError', label: 'Fail the run on record errors', kind: 'bool', defaultValue: true, description: 'When off, per-record errors are logged and the stage continues. Set Results directory to capture per-record outcomes either way.' },
+                    { key: 'resultsPath', label: 'Results directory', kind: 'text', placeholder: '${workspace}/out/sf-results', description: 'When set, writes Data-Loader-style per-run result files, stamped {object}_{operation}_{runtime}: ..._success.csv (input columns + sf__Id) and ..._error.csv (+ sf__StatusCode, sf__Message) - written even when the run fails.' },
                 ],
             },
         ], 'upstream');


### PR DESCRIPTION
Second of the two follow-ups proposed in #166 (the first, `visibleWhen`, landed in #176): per-record result files from the Salesforce sink, mirroring what Data Loader users expect after a load.

**What it does**

Setting the new optional `resultsPath` (Results directory) on `snk.salesforce` writes two files after every run, stamped with the job and UTC run time so repeat runs accumulate side by side instead of overwriting - and multiple Salesforce sinks can share one directory:

- `{object}_{operation}_{yyyymmddThhmmssZ}_success.csv` - input columns + `sf__Id` (the created/updated record Id)
- `{object}_{operation}_{yyyymmddThhmmssZ}_error.csv` - input columns + `sf__StatusCode` + `sf__Message`

(e.g. `Account_insert_20260715T035428Z_success.csv`)

Semantics (documented in IMPLEMENTATION.md):

- Both files are **always** written, header-only when a side is empty (Data Loader parity).
- Files land **even when the stage errors** - `failOnError` abort, HTTP status/transport failure - so the reject stream survives a failed run. A chunk rejected wholesale fails each of its rows with `HTTP_<code>` / `HTTP_TRANSPORT`; chunks never attempted (an earlier chunk aborted) appear in neither file.
- Header = first row's column order, union-extended with later rows' extras; input columns colliding with the `sf__` names are skipped so the report values win. RFC 4180 quoting, hand-rolled - no new dependency.

**Implementation**

`parse_salesforce_results` now returns one positionally-aligned result per submitted record instead of aggregate counts; the chunk loop funnels every exit path through a single file-writing point. One deliberate behavior change to flag: an API-level (non-array) error body now counts as a failure for **every** record in the chunk rather than a single failure - the old accounting understated failures for batches >1.

**Frontend**: `resultsPath` text field in the sink's Destination section; `catalog.json` regenerated via the generator.

**Tests**: 8 new unit tests (CSV escaping/cells, header union + collision skip, header-only sides, non-array/short-array parsing) + 3 new mock-server e2e tests (mixed batch splits files + stamped-name shape; files written despite `failOnError` abort; no files without `resultsPath`). Full engine suite green.

**Live suite**: `s1` now sets `resultsPath` and asserts the stamped files against a real org (17/17 passing). Also updated `s5` to declare its source schema per the #170 fix contract, so the org-clean check reads a typed header-only csv instead of pattern-matching the old binder-error workaround.
