### PR TITLE
fix(salesforce): #164 Bulk query result-walk guards + text-preserving no-schema reads

### DIFF
--- a/crates/duckdb-engine/src/connectors.rs
+++ b/crates/duckdb-engine/src/connectors.rs
@@ -1026,6 +1026,7 @@ impl DuckdbEngine {
         // edge of the API.
         let mut total_rows: u64 = 0;
         let mut locator: Option<String> = None;
+        let mut pages_fetched: u64 = 0;
         loop {
             self.check_cancelled()?;
             let mut url = format!("{}/{}/results", query_base, job_id);
@@ -1075,8 +1076,34 @@ impl DuckdbEngine {
                     e
                 ))
             })?;
+            pages_fetched += 1;
             match next.as_deref() {
                 Some("null") | Some("") | None => break,
+                // Runaway guards: timeoutSecs only bounds the POLL phase, so
+                // the page walk needs its own. A peer (or interfering
+                // middlebox) that echoes the same locator back would otherwise
+                // re-append the same page forever; a locator that keeps
+                // changing is still capped far above any real result set
+                // (50M pages even at the 1000-record floor is 50B records).
+                Some(loc) if locator.as_deref() == Some(loc) => {
+                    return Err(EngineError::Query(format!(
+                        "salesforce bulk: query job {} returned a non-advancing \
+                         Sforce-Locator ('{}') on page {}; aborting the result walk \
+                         rather than re-fetching the same page forever",
+                        job_id,
+                        loc,
+                        pages_fetched
+                    )));
+                }
+                Some(loc) if pages_fetched >= BULK_QUERY_MAX_PAGES => {
+                    return Err(EngineError::Query(format!(
+                        "salesforce bulk: query job {} exceeded {} result pages \
+                         (last locator '{}'); this is a runaway backstop, not a \
+                         tunable - a genuine result set this large should be split \
+                         with WHERE clauses",
+                        job_id, BULK_QUERY_MAX_PAGES, loc
+                    )));
+                }
                 Some(loc) => locator = Some(loc.to_string()),
             }
         }
@@ -1140,8 +1167,14 @@ impl DuckdbEngine {
                     csv_target
                 )
             }
+            // No declared schema: read everything as text rather than letting
+            // read_csv sniff types - inference turns a 01234 postcode into
+            // BIGINT 1234 and silently drops the leading zero. Salesforce
+            // serves every value as CSV text anyway; casting is a downstream
+            // choice the user makes deliberately (or by declaring a schema,
+            // which pins types via TRY_CAST above).
             _ => format!(
-                "CREATE OR REPLACE TABLE {} AS SELECT * FROM read_csv('{}', header=true);",
+                "CREATE OR REPLACE TABLE {} AS SELECT * FROM read_csv('{}', header=true, all_varchar=true);",
                 plan::quote_ident(&spec.node_id),
                 csv_target
             ),
@@ -10415,6 +10448,12 @@ fn salesforce_record_envelope(row: &JsonValue, object: &str) -> JsonValue {
 /// these to 150 - the 150 is a post-base64 number, not a raw-CSV one.
 const BULK_SPLIT_TARGET_BYTES: u64 = 90 * 1024 * 1024;
 const BULK_UPLOAD_MAX_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Runaway backstop on the Bulk query result walk, NOT a tunable: at the
+/// server's 1000-record page floor this is 50 billion records, far beyond any
+/// legitimate extract. The walk's real guard is the non-advancing-locator
+/// check; this cap only bounds a peer that keeps minting fresh locators.
+const BULK_QUERY_MAX_PAGES: u64 = 50_000_000;
 
 /// Terminal snapshot of a Bulk API 2.0 ingest job.
 struct BulkJobStatus {

--- a/crates/duckdb-engine/tests/execution.rs
+++ b/crates/duckdb-engine/tests/execution.rs
@@ -12344,6 +12344,9 @@ fn snk_salesforce_bulk_failed_records_inline_first_errors() {
 
 struct BulkQueryMock {
     job_state: &'static str,
+    /// When true, /results always serves page 0 with a constant non-advancing
+    /// Sforce-Locator, emulating a peer/middlebox that echoes the same token.
+    stuck: bool,
     /// One entry per result page: (csv body, Sforce-Locator value returned
     /// WITH that page, Sforce-NumberOfRecords). The last page's locator is the
     /// literal string "null", exactly as the real API signals it.
@@ -12405,6 +12408,21 @@ fn sf_bulk_query_mock_server(cfg: BulkQueryMock) -> (u16, std::sync::mpsc::Recei
                     r#"{"id":"QJOB1","state":"UploadComplete"}"#.to_string(),
                 )
             } else if method == "GET" && path.contains("/results") {
+                if cfg.stuck {
+                    let (csv, _, nrecords) = cfg.pages[0];
+                    let resp_parts = (
+                        "200 OK",
+                        "text/csv",
+                        format!(
+                            "Sforce-Locator: STUCK
+Sforce-NumberOfRecords: {}
+",
+                            nrecords
+                        ),
+                        csv.to_string(),
+                    );
+                    resp_parts
+                } else {
                 // Page selection: no locator param -> page 0; locator=P{n} -> page n.
                 let idx = path
                     .split("locator=P")
@@ -12431,6 +12449,7 @@ fn sf_bulk_query_mock_server(cfg: BulkQueryMock) -> (u16, std::sync::mpsc::Recei
                         )
                     }
                     None => ("404 Not Found", "text/csv", String::new(), String::new()),
+                }
                 }
             } else if method == "PATCH" {
                 (
@@ -12481,9 +12500,10 @@ fn src_salesforce_bulk_walks_locator_pages_in_order() {
     // stop on the LITERAL "null" locator - yielding all 3 rows in order.
     let (port, _rx) = sf_bulk_query_mock_server(BulkQueryMock {
         job_state: "JobComplete",
+        stuck: false,
         pages: vec![
-            ("Id,Name\n001A,Acme\n001B,Globex\n", "P1", 2),
-            ("Id,Name\n001C,Initech\n", "null", 1),
+            ("Id,Name,Zip\n001A,Acme,01234\n001B,Globex,02002\n", "P1", 2),
+            ("Id,Name,Zip\n001C,Initech,00042\n", "null", 1),
         ],
     });
 
@@ -12521,6 +12541,14 @@ fn src_salesforce_bulk_walks_locator_pages_in_order() {
         "pages must land in order: {}",
         written
     );
+    // No declared schema: values must survive as text, not get sniffed into
+    // numerics - a 01234 postcode losing its leading zero is silent data
+    // corruption for a migration source.
+    assert!(
+        lines[1].contains("01234") && lines[3].contains("00042"),
+        "leading zeros must survive the no-schema read: {}",
+        written
+    );
 }
 
 #[test]
@@ -12530,6 +12558,7 @@ fn src_salesforce_bulk_zero_records_yields_typed_empty_relation() {
     // relation downstream SQL can bind, landing as a header-only csv.
     let (port, _rx) = sf_bulk_query_mock_server(BulkQueryMock {
         job_state: "JobComplete",
+        stuck: false,
         pages: vec![("Id,Name\n", "null", 0)],
     });
 
@@ -12583,6 +12612,7 @@ fn src_salesforce_bulk_failed_job_surfaces_error() {
     let engine = engine_or_skip!();
     let (port, _rx) = sf_bulk_query_mock_server(BulkQueryMock {
         job_state: "Failed",
+        stuck: false,
         pages: vec![],
     });
 
@@ -12621,6 +12651,7 @@ fn src_salesforce_bulk_poll_timeout_aborts_job() {
     let engine = engine_or_skip!();
     let (port, rx) = sf_bulk_query_mock_server(BulkQueryMock {
         job_state: "InProgress",
+        stuck: false,
         pages: vec![],
     });
 
@@ -12662,5 +12693,47 @@ fn src_salesforce_bulk_poll_timeout_aborts_job() {
         last_patch_body.contains("Aborted"),
         "expected a final PATCH {{state: Aborted}}, got body: {}",
         last_patch_body
+    );
+}
+
+#[test]
+fn src_salesforce_bulk_non_advancing_locator_errors() {
+    let engine = engine_or_skip!();
+    // A peer that echoes the same Sforce-Locator back forever must fail the
+    // run, not re-append the same page until the disk fills.
+    let (port, _rx) = sf_bulk_query_mock_server(BulkQueryMock {
+        job_state: "JobComplete",
+        stuck: true,
+        pages: vec![("Id,Name
+001A,Acme
+", "P1", 1)],
+    });
+
+    let tmp = tempfile::tempdir().unwrap();
+    let out = tmp.path().join("x.csv").to_string_lossy().replace('\\', "/");
+    let instance = format!("http://127.0.0.1:{}", port);
+    let r = engine.execute_pipeline(&doc(
+        json!([
+            node(
+                "q",
+                "src.salesforce.bulk",
+                json!({
+                    "instanceUrl": instance,
+                    "accessToken": "tok-123",
+                    "query": "SELECT Id FROM Account",
+                    "pollIntervalSecs": 1,
+                    "timeoutSecs": 30
+                }),
+            ),
+            node("f", "snk.csv", json!({ "path": out, "mode": "overwrite", "hasHeader": true })),
+        ]),
+        json!([main_edge("e", "q", "f")]),
+    ));
+    assert_eq!(r.status, "error", "a non-advancing locator must fail the run");
+    let err = r.error.unwrap_or_default();
+    assert!(
+        err.contains("non-advancing") && err.contains("QJOB1") && err.contains("STUCK"),
+        "error should name the job and the stuck locator, got: {}",
+        err
     );
 }

--- a/docs/salesforce-sink/IMPLEMENTATION.md
+++ b/docs/salesforce-sink/IMPLEMENTATION.md
@@ -215,7 +215,16 @@ materializes a typed empty relation (`materialize_empty_result`); without a
 schema it fails with a clear source-level error rather than the bare `json`
 column of old. With rows and a declared schema, the columns are pinned via
 `all_varchar` + `TRY_CAST` (a stray unparseable cell becomes NULL rather than
-failing the load); without one, `read_csv` inference applies.
+failing the load); without one, every column reads as text (`all_varchar`) -
+Salesforce serves CSV text either way, and letting `read_csv` sniff types
+turns a `01234` postcode into BIGINT `1234`, which is silent corruption. Cast
+downstream, or declare a schema to pin types.
+
+**Result-walk guards.** `timeoutSecs` bounds only the poll phase, so the page
+walk carries its own: a non-advancing `Sforce-Locator` (a peer or middlebox
+echoing the same token) fails the run rather than re-appending the same page
+forever, and a far-out page ceiling backstops a peer that keeps minting fresh
+locators.
 
 **SOQL restrictions.** Bulk 2.0 queries reject GROUP BY, OFFSET, TYPEOF,
 aggregates and parent-to-child subqueries at job creation; compound fields


### PR DESCRIPTION
The fast-follow promised on #196, covering both remaining review items:

**Runaway guards on the result page walk.** `timeoutSecs` bounds only the poll phase, so the walk now carries its own: a non-advancing `Sforce-Locator` (a peer or middlebox echoing the same token back) fails the run naming the job and the stuck locator, instead of re-appending the same page until the disk fills. A far-out page ceiling (50M pages — commented as a runaway backstop, not a tunable) additionally bounds a peer that keeps minting fresh locators.

**Text-preserving no-schema reads.** Without a declared schema the read now passes `all_varchar` to `read_csv` rather than letting inference sniff types — a `BillingPostalCode` of `01234` sniffed to BIGINT `1234`, silently dropping the leading zero. Salesforce serves every value as CSV text anyway; casting becomes a deliberate downstream choice, and a declared schema still pins types via `TRY_CAST` exactly as before.

Tests: a new mock e2e drives the non-advancing-locator failure (the query mock gained a stuck-locator mode), and the pagination e2e now also asserts leading-zero survival — an assertion that fails without the `all_varchar` change. 5 source e2e + the full Salesforce suite (17 unit + 19 e2e, including your two post-#196 fixes' tests) green. IMPLEMENTATION.md updated for both behaviours.