### PR TITLE
Fix Python pipeline limit serialization

### DIFF
--- a/packaging/pypi/duckle/api.py
+++ b/packaging/pypi/duckle/api.py
@@ -182,7 +182,7 @@ class Pipeline:
         return self._add("transform", "xf.sort", {"orderBy": order}, "Sort")
 
     def limit(self, n):
-        return self._add("transform", "xf.limit", {"count": int(n)}, "Limit")
+        return self._add("transform", "xf.limit", {"limit": int(n)}, "Limit")
 
     def dedupe(self, *columns):
         return self._add("transform", "xf.distinct", {"columns": list(columns)}, "Dedupe")

--- a/packaging/pypi/tests/test_api.py
+++ b/packaging/pypi/tests/test_api.py
@@ -1,0 +1,16 @@
+import unittest
+
+import duckle
+
+
+class PipelineTests(unittest.TestCase):
+    def test_limit_uses_engine_property_name(self):
+        pipeline = duckle.read_csv("input.csv").limit(7)
+
+        properties = pipeline.to_dict()["nodes"][-1]["data"]["properties"]
+
+        self.assertEqual(properties, {"limit": 7})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this changes

Serialize Python `Pipeline.limit(n)` nodes with the engine-supported `limit` property instead of `count`. This prevents the compiler from silently falling back to `LIMIT 100`, and adds a focused regression test for the Python-to-engine contract.

## Related issue

Fixes #198

## Type

- [x] Bug fix
- [ ] New feature (connector / transform / sink)
- [ ] Performance
- [ ] Docs
- [ ] Refactor / internal

## Checklist

- [ ] `cargo fmt` and `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] `cargo test --workspace` passes (engine tests need `DUCKLE_DUCKDB_BIN` set - see CONTRIBUTING.md)
- [ ] `npm --prefix frontend run lint` passes (if the frontend changed)
- [x] Commits are small with imperative subject lines
- [x] No code ported from incompatibly licensed sources

## Notes for reviewers

Validated locally with:

- `PYTHONPATH=packaging/pypi python3 -m unittest discover -s packaging/pypi/tests -v`
- an end-to-end Python API compile assertion confirming `.limit(7)` produces `LIMIT 7`
- `cargo test --workspace`
- `git diff --check`

The frontend was not changed, so its lint command is not applicable. On the current upstream revision, the Rust 1.93 formatter and clippy commands report existing failures in untouched Rust files (including `crates/connectors/src/csv.rs` and `crates/duckdb-engine/tests/execution.rs`); this PR does not modify Rust code.
