### PR TITLE
fix(workspace): support inline duckle.json rollups and robust active job recovery (#213)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -589,9 +589,9 @@ export default function App() {
                 }
                 if (state) {
                     if (state.engine) setEngine(normalizeEngineId(state.engine));
-                    if (state.pipelineData && Object.keys(state.pipelineData).length > 0)
+                    if (state.pipelineData)
                         setPipelineData(state.pipelineData as Record<string, PipelineState>);
-                    if (state.repo && (state.repo as RepoItem[]).length > 0)
+                    if (state.repo)
                         setRepo(state.repo as RepoItem[]);
                     if (state.jobs && (state.jobs as Job[]).length > 0) {
                         const loadedJobs = state.jobs as Job[];

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -589,11 +589,21 @@ export default function App() {
                 }
                 if (state) {
                     if (state.engine) setEngine(normalizeEngineId(state.engine));
-                    if (state.pipelineData)
+                    if (state.pipelineData && Object.keys(state.pipelineData).length > 0)
                         setPipelineData(state.pipelineData as Record<string, PipelineState>);
-                    if (state.repo) setRepo(state.repo as RepoItem[]);
-                    if (state.jobs) setJobs(state.jobs as Job[]);
-                    if (state.activeJobId) setActiveJobId(state.activeJobId);
+                    if (state.repo && (state.repo as RepoItem[]).length > 0)
+                        setRepo(state.repo as RepoItem[]);
+                    if (state.jobs && (state.jobs as Job[]).length > 0) {
+                        const loadedJobs = state.jobs as Job[];
+                        setJobs(loadedJobs);
+                        const targetActiveId =
+                            state.activeJobId && loadedJobs.some(j => j.id === state.activeJobId)
+                                ? state.activeJobId
+                                : loadedJobs[0].id;
+                        setActiveJobId(targetActiveId);
+                    } else if (state.activeJobId) {
+                        setActiveJobId(state.activeJobId);
+                    }
                     if (state.corruptFiles?.length) setCorruptFiles(state.corruptFiles);
                 }
                 setWorkspaceReady(true);

--- a/frontend/src/workspace.ts
+++ b/frontend/src/workspace.ts
@@ -297,7 +297,9 @@ async function loadV2(path: string): Promise<WorkspaceState | null> {
         }
     }
 
-    // Scan pipelines/ directory for any pipeline files on disk not explicitly referenced in repo
+    // Auto-register any pipeline files present on disk in `pipelines/` that are
+    // missing from repository.json. This is intentional for workspace recovery
+    // (e.g. from git merges or rollups where repository.json is partial).
     const diskPipelineFiles = await readDirEntries(joinPath(path, PIPELINES_DIR));
     for (const pfile of diskPipelineFiles) {
         const pid = pfile.replace(/\.json$/i, '');

--- a/frontend/src/workspace.ts
+++ b/frontend/src/workspace.ts
@@ -245,12 +245,14 @@ async function loadV2(path: string): Promise<WorkspaceState | null> {
         engine?: string;
         jobs?: unknown[];
         activeJobId?: string;
+        pipelineData?: Record<string, unknown>;
+        repo?: unknown[];
     }>(joinPath(path, METADATA_FILE));
     if (!meta) return null;
 
-    const repo = (await readJsonIfExists<Array<Record<string, unknown>>>(
+    let repo = (await readJsonIfExists<Array<Record<string, unknown>>>(
         joinPath(path, REPOSITORY_FILE),
-    )) ?? [];
+    )) ?? (meta.repo as Array<Record<string, unknown>> | undefined) ?? [];
 
     // Per-item files (contexts, connections, pipelines) are loaded
     // independently: a single corrupt one is skipped and reported, never
@@ -279,8 +281,10 @@ async function loadV2(path: string): Promise<WorkspaceState | null> {
         }
     }
 
-    // Load each pipeline file referenced in the repo.
-    const pipelineData: Record<string, unknown> = {};
+    // Load each pipeline file referenced in the repo (and merge inline pipelineData from meta if present).
+    const pipelineData: Record<string, unknown> = {
+        ...((meta.pipelineData as Record<string, unknown> | undefined) ?? {}),
+    };
     for (const item of repo) {
         if (item.type !== 'pipeline') continue;
         const file = joinPath(path, PIPELINES_DIR, `${item.id}.json`);
@@ -293,11 +297,85 @@ async function loadV2(path: string): Promise<WorkspaceState | null> {
         }
     }
 
+    // Scan pipelines/ directory for any pipeline files on disk not explicitly referenced in repo
+    const diskPipelineFiles = await readDirEntries(joinPath(path, PIPELINES_DIR));
+    for (const pfile of diskPipelineFiles) {
+        const pid = pfile.replace(/\.json$/i, '');
+        if (!pipelineData[pid]) {
+            try {
+                const pipeline = await readJsonIfExists(joinPath(path, PIPELINES_DIR, pfile));
+                if (pipeline) {
+                    pipelineData[pid] = pipeline;
+                    if (!repo.some(r => r.id === pid)) {
+                        repo.push({
+                            id: pid,
+                            name: pid,
+                            type: 'pipeline',
+                            parentId: 'pipelines',
+                        });
+                    }
+                }
+            } catch (err) {
+                if (err instanceof WorkspaceLoadError) corruptFiles.push(err.file);
+            }
+        }
+    }
+
+    // Derive or recover jobs: if meta.jobs is empty, infer from repo / pipelineData
+    let jobs = meta.jobs as Array<{ id: string; name?: string; dirty?: boolean }> | undefined;
+    if (!jobs || jobs.length === 0) {
+        const pipelineItems = repo.filter(i => i.type === 'pipeline');
+        if (pipelineItems.length > 0) {
+            jobs = pipelineItems.map(i => ({
+                id: String(i.id),
+                name: (i.name as string) || String(i.id),
+                dirty: false,
+            }));
+        } else {
+            const pids = Object.keys(pipelineData);
+            if (pids.length > 0) {
+                jobs = pids.map(id => ({ id, name: id, dirty: false }));
+            }
+        }
+    }
+
+    // Ensure repo has items if empty but pipelineData exists
+    if (repo.length === 0 && Object.keys(pipelineData).length > 0) {
+        repo = Object.keys(pipelineData).map(id => ({
+            id,
+            name: jobs?.find(j => j.id === id)?.name || id,
+            type: 'pipeline',
+            parentId: 'pipelines',
+        }));
+    }
+
+    // Determine activeJobId fallback
+    let activeJobId = meta.activeJobId;
+    if (!activeJobId && jobs && jobs.length > 0) {
+        activeJobId = jobs[0].id;
+    }
+
+    // Fallback: If duckle.json exists but is minimal/empty (0 jobs & 0 pipelines), check if workspace.json has content
+    if ((!jobs || jobs.length === 0) && Object.keys(pipelineData).length === 0) {
+        const v1 = await readJsonIfExists<WorkspaceState>(joinPath(path, V1_FILE));
+        if (v1 && ((v1.jobs && v1.jobs.length > 0) || (v1.pipelineData && Object.keys(v1.pipelineData).length > 0))) {
+            return {
+                version: meta.version ?? 2,
+                engine: meta.engine ?? v1.engine,
+                jobs: v1.jobs ?? jobs,
+                activeJobId: meta.activeJobId ?? v1.activeJobId,
+                repo: (v1.repo as Array<Record<string, unknown>>) ?? repo,
+                pipelineData: (v1.pipelineData as Record<string, unknown>) ?? pipelineData,
+                corruptFiles: corruptFiles.length ? corruptFiles : undefined,
+            };
+        }
+    }
+
     return {
         version: meta.version ?? 2,
         engine: meta.engine,
-        jobs: meta.jobs,
-        activeJobId: meta.activeJobId,
+        jobs,
+        activeJobId,
         repo,
         pipelineData,
         corruptFiles: corruptFiles.length ? corruptFiles : undefined,


### PR DESCRIPTION
﻿### Description
Fixes #213

This PR resolves an issue where opening valid workspaces (such as CLI-generated rollups, single-file exports, or workspaces where pipelines/jobs are in `duckle.json` or `workspace.json`) would fail to hydrate the active job list and incorrectly fall back to displaying the starter `orders_etl` project.

### Root Cause
1. `loadV2` in `frontend/src/workspace.ts` ignored inline `pipelineData` and `repo` embedded in `duckle.json`, and only looked for items in `repository.json` and `pipelines/*.json`.
2. When `duckle.json` lacked an explicit `jobs` array or separate `repository.json`, `jobs` stayed `undefined` and `pipelineData` remained empty, leaving `App.tsx` on the default `orders_etl` state.
3. If `duckle.json` was minimal/empty while `workspace.json` held the actual jobs/pipelines, `loadV2` did not fall back to `workspace.json`.

### Changes
- **`frontend/src/workspace.ts`**:
  - Support reading inline `pipelineData` and `repo` from `duckle.json`.
  - Scan the `pipelines/` folder for any on-disk pipelines not yet in `repository.json` and auto-register them in `repo`.
  - Dynamically derive `jobs` and `activeJobId` from `repo` or `pipelineData` when `meta.jobs` is not provided.
  - Add seamless fallback hydration from `workspace.json` if `duckle.json` contains no jobs or pipelines.
- **`frontend/src/App.tsx`**:
  - Ensure `setActiveJobId` uses the loaded `state.activeJobId` or the first loaded job rather than keeping the default starter job ID.
