### PR TITLE
fix(build): resolve Linux static unixODBC linking and fix build warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,7 +13,20 @@
 # On a non-Debian distro, point ODBC_SYS_STATIC_PATH at your unixODBC lib dir
 # instead (or adjust the path below); on Windows/macOS this file does nothing.
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-L", "native=/usr/lib/x86_64-linux-gnu"]
+rustflags = [
+    "-L", "native=/home/darekdan/.local/lib",
+    "-L", "native=/usr/local/lib",
+    "-L", "native=/usr/lib/x86_64-linux-gnu",
+    "-L", "native=/usr/lib64",
+    "-L", "native=/usr/lib",
+]
 
 [target.aarch64-unknown-linux-gnu]
-rustflags = ["-L", "native=/usr/lib/aarch64-linux-gnu"]
+rustflags = [
+    "-L", "native=/home/darekdan/.local/lib",
+    "-L", "native=/usr/local/lib",
+    "-L", "native=/usr/lib/aarch64-linux-gnu",
+    "-L", "native=/usr/lib64",
+    "-L", "native=/usr/lib",
+]
+

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,23 +10,30 @@
 # targets. The musl target is intentionally absent: the musl runner excludes
 # Teradata entirely.
 #
-# On a non-Debian distro, point ODBC_SYS_STATIC_PATH at your unixODBC lib dir
-# instead (or adjust the path below); on Windows/macOS this file does nothing.
+# Distros that do not use multiarch (Arch, Fedora) keep the archives in
+# /usr/lib64 or /usr/local/lib, so those follow as fallbacks. The multiarch dir
+# stays FIRST: these flags apply to every build for the triple, including the
+# release job that produces the published Linux binaries, and that job must keep
+# linking the same archives it links today.
+#
+# A path under a home directory does NOT belong here - this file is committed and
+# shared, and a home directory is writable by whoever owns it. For a lib dir
+# outside these, set ODBC_SYS_STATIC_PATH; build.rs adds it (and $HOME/.local/lib)
+# to the search path for your build alone, gated on the teradata-static feature.
+# On Windows/macOS this file does nothing.
 [target.x86_64-unknown-linux-gnu]
 rustflags = [
-    "-L", "native=/home/darekdan/.local/lib",
-    "-L", "native=/usr/local/lib",
     "-L", "native=/usr/lib/x86_64-linux-gnu",
     "-L", "native=/usr/lib64",
+    "-L", "native=/usr/local/lib",
     "-L", "native=/usr/lib",
 ]
 
 [target.aarch64-unknown-linux-gnu]
 rustflags = [
-    "-L", "native=/home/darekdan/.local/lib",
-    "-L", "native=/usr/local/lib",
     "-L", "native=/usr/lib/aarch64-linux-gnu",
     "-L", "native=/usr/lib64",
+    "-L", "native=/usr/local/lib",
     "-L", "native=/usr/lib",
 ]
 

--- a/crates/duckdb-engine/build.rs
+++ b/crates/duckdb-engine/build.rs
@@ -13,10 +13,19 @@ fn main() {
     let is_linux = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux");
     if teradata_static && is_linux {
         let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        if let Ok(home) = std::env::var("HOME") {
+            println!("cargo:rustc-link-search=native={home}/.local/lib");
+        }
+        if let Ok(static_path) = std::env::var("ODBC_SYS_STATIC_PATH") {
+            println!("cargo:rustc-link-search=native={static_path}");
+        }
+        println!("cargo:rustc-link-search=native=/usr/local/lib");
         println!("cargo:rustc-link-search=native=/usr/lib/{arch}-linux-gnu");
+        println!("cargo:rustc-link-search=native=/usr/lib64");
         println!("cargo:rustc-link-search=native=/usr/lib");
         println!("cargo:rustc-link-lib=static=odbcinst");
         println!("cargo:rustc-link-lib=dylib=dl");
         println!("cargo:rustc-link-lib=dylib=pthread");
     }
 }
+

--- a/crates/duckdb-engine/src/connectors.rs
+++ b/crates/duckdb-engine/src/connectors.rs
@@ -3137,7 +3137,7 @@ impl DuckdbEngine {
         };
         let props = WriterProperties::builder()
             .set_statistics_enabled(EnabledStatistics::None)
-            .set_max_row_group_size(row_group)
+            .set_max_row_group_row_count(Some(row_group))
             .set_compression(codec)
             // The default 1 MB dictionary budget is per column, and a wide fact
             // table full of repeated text blows through it immediately; once it
@@ -3735,7 +3735,7 @@ impl DuckdbEngine {
             .options
             .iter()
             .map(|(k, v)| (OptionDatabase::from(k.as_str()), OptionValue::String(v.clone())));
-        let mut database = driver
+        let database = driver
             .new_database_with_opts(opts)
             .map_err(|e| EngineError::Query(format!("adbc: open database: {}", e)))?;
         let mut conn = database
@@ -3782,7 +3782,7 @@ impl DuckdbEngine {
         use parquet::file::properties::{EnabledStatistics, WriterProperties};
         let props = WriterProperties::builder()
             .set_statistics_enabled(EnabledStatistics::None)
-            .set_max_row_group_size(1_000_000)
+            .set_max_row_group_row_count(Some(1_000_000))
             .build();
         let writer_schema = schema.clone();
         let (tx, rx) = std::sync::mpsc::sync_channel::<arrow_array::RecordBatch>(8);
@@ -3913,7 +3913,7 @@ impl DuckdbEngine {
             .options
             .iter()
             .map(|(k, v)| (OptionDatabase::from(k.as_str()), OptionValue::String(v.clone())));
-        let mut database = driver
+        let database = driver
             .new_database_with_opts(opts)
             .map_err(|e| EngineError::Query(format!("adbc: open database: {}", e)))?;
         let mut conn = database
@@ -9652,7 +9652,7 @@ impl DuckdbEngine {
                 .resolve(&schema)
                 .map_err(|e| EngineError::Query(format!("avro: encode row: {}", e)))?;
             writer
-                .append(value)
+                .append_value(value)
                 .map_err(|e| EngineError::Query(format!("avro: append: {}", e)))?;
             total += 1;
         }
@@ -17910,7 +17910,11 @@ pub(crate) fn avro_datum_to_json(
     payload: &[u8],
 ) -> Result<JsonValue, String> {
     let mut cursor = payload;
-    let value = apache_avro::from_avro_datum(schema, &mut cursor, None)
+    let reader = apache_avro::reader::datum::GenericDatumReader::builder(schema)
+        .build()
+        .map_err(|e| format!("avro decode: {}", e))?;
+    let value = reader
+        .read_value(&mut cursor)
         .map_err(|e| format!("avro decode: {}", e))?;
     JsonValue::try_from(value).map_err(|e| format!("avro value to json: {}", e))
 }

--- a/crates/duckdb-engine/src/pyexpr.rs
+++ b/crates/duckdb-engine/src/pyexpr.rs
@@ -57,6 +57,7 @@ enum Ast {
     In(Box<Ast>, Vec<Ast>, bool),
     /// `x is None` / `x is not None`
     IsNull(Box<Ast>, bool),
+    #[allow(dead_code)]
     Tuple(Vec<Ast>),
 }
 

--- a/crates/duckdb-engine/src/talend.rs
+++ b/crates/duckdb-engine/src/talend.rs
@@ -3183,7 +3183,7 @@ fn extract_loop_bodies(
 ) -> Vec<Import> {
     let mut children = Vec::new();
     for loop_id in loop_nodes(nodes) {
-        let mut body = loop_body_members(&loop_id, edges);
+        let body = loop_body_members(&loop_id, edges);
         if body.is_empty() {
             continue;
         }

--- a/crates/duckdb-engine/src/xsd.rs
+++ b/crates/duckdb-engine/src/xsd.rs
@@ -100,7 +100,9 @@ fn attrs(e: &quick_xml::events::BytesStart) -> BTreeMap<String, String> {
         .map(|a| {
             (
                 a.key.as_ref().to_string(),
-                a.unescape_value().map(|v| v.to_string()).unwrap_or_default(),
+                a.normalized_value(quick_xml::XmlVersion::Implicit1_0)
+                    .map(|v| v.to_string())
+                    .unwrap_or_default(),
             )
         })
         .collect()

--- a/crates/duckle-runner/Cargo.toml
+++ b/crates/duckle-runner/Cargo.toml
@@ -68,3 +68,4 @@ duckle-duckdb-engine = { workspace = true, features = ["teradata-static"] }
 
 [dev-dependencies]
 tempfile = "3"
+

--- a/crates/duckle-runner/src/audit.rs
+++ b/crates/duckle-runner/src/audit.rs
@@ -13,7 +13,7 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::console_auth::{Identity, Role};
 

--- a/crates/duckle-runner/src/auth_store.rs
+++ b/crates/duckle-runner/src/auth_store.rs
@@ -44,6 +44,7 @@ pub struct ApiKeyInfo {
 
 impl ApiKeyInfo {
     /// Whether this key would be accepted right now.
+    #[allow(dead_code)]
     pub fn is_live(&self, now: i64) -> bool {
         !self.revoked && self.expires_at.is_none_or(|e| e > now)
     }

--- a/crates/duckle-runner/src/build.rs
+++ b/crates/duckle-runner/src/build.rs
@@ -19,7 +19,6 @@ use base64::Engine as _;
 use duckle_duckdb_engine::{is_secret_prop_key, PipelineDoc};
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -1013,9 +1012,8 @@ fn encrypt_secrets(key_map: &[(String, String)]) -> Result<String, String> {
     let cipher = Aes256Gcm::new_from_slice(&key).map_err(|e| format!("cipher init: {}", e))?;
     let mut nonce_bytes = [0u8; 12];
     getrandom::fill(&mut nonce_bytes).map_err(|e| format!("nonce: {}", e))?;
-    let nonce = Nonce::from_slice(&nonce_bytes);
     let ciphertext = cipher
-        .encrypt(nonce, plain.as_bytes())
+        .encrypt(&Nonce::from(nonce_bytes), plain.as_bytes())
         .map_err(|e| format!("encrypt: {}", e))?;
 
     let mut payload = Vec::with_capacity(BUNDLE_MAGIC.len() + BUNDLE_SALT_LEN + 12 + ciphertext.len());
@@ -1103,8 +1101,9 @@ fn render_manifest(
 
 
 #[cfg(test)]
-mod bundle_key_tests {
+mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
 
     /// secrets.enc ships inside the bundle, so whoever holds the artifact can attack
     /// the passphrase offline. The original key was `Sha256::digest(passphrase)`: no

--- a/crates/duckle-runner/src/main.rs
+++ b/crates/duckle-runner/src/main.rs
@@ -629,9 +629,9 @@ fn load_secrets_enc(workspace: &Path) -> Result<Option<HashMap<String, String>>,
         (Sha256::digest(passphrase.as_bytes()).to_vec(), nonce_bytes, ciphertext)
     };
     let cipher = Aes256Gcm::new_from_slice(&key).map_err(|e| format!("cipher init: {}", e))?;
-    let nonce = Nonce::from_slice(nonce_bytes);
+    let nonce = Nonce::try_from(nonce_bytes).map_err(|e| format!("nonce: {}", e))?;
     let plain = cipher
-        .decrypt(nonce, ciphertext)
+        .decrypt(&nonce, ciphertext)
         .map_err(|_| "wrong DUCKLE_BUNDLE_PASSPHRASE or corrupt secrets.enc".to_string())?;
     let text = String::from_utf8(plain).map_err(|e| format!("secrets.enc not UTF-8: {}", e))?;
     Ok(Some(parse_env_file(&text)))

--- a/crates/duckle-runner/src/pipetest.rs
+++ b/crates/duckle-runner/src/pipetest.rs
@@ -104,6 +104,7 @@ pub struct Case {
 
 /// One failure, said in terms of the case rather than of the engine.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct Failure {
     pub case: String,
     pub why: String,
@@ -412,6 +413,7 @@ fn same_cell(
     text(want) == text(got)
 }
 
+#[allow(dead_code)]
 pub fn compare(expected: &[JsonValue], actual: &[JsonValue]) -> Option<String> {
     compare_with(expected, actual, false)
 }
@@ -426,6 +428,7 @@ pub fn compare_within(
     compare_inner(expected, actual, coerce, tolerance)
 }
 
+#[allow(dead_code)]
 pub fn compare_with(expected: &[JsonValue], actual: &[JsonValue], coerce: bool) -> Option<String> {
     compare_inner(expected, actual, coerce, None)
 }

--- a/crates/duckle-runner/src/serve.rs
+++ b/crates/duckle-runner/src/serve.rs
@@ -1460,6 +1460,7 @@ fn respond_403(msg: &str) -> Reply {
     respond("403 Forbidden", "text/plain", msg.as_bytes())
 }
 
+#[allow(dead_code)]
 fn handle(mut stream: TcpStream, state: &Arc<State>) -> Result<(), String> {
     let req = read_request(&mut stream)?;
     let reply = route_console(&req, state);
@@ -1590,6 +1591,7 @@ fn public_route(req: &Request, state: &State) -> Reply {
     sign_in(state, req)
 }
 
+#[allow(dead_code)]
 fn route_console(req: &Request, state: &Arc<State>) -> Reply {
     match authorize(req, state) {
         Access::Refused(reply) => reply,

--- a/crates/duckle-secrets/src/lib.rs
+++ b/crates/duckle-secrets/src/lib.rs
@@ -121,7 +121,7 @@ pub fn encrypt_value(key: &[u8; 32], aad: &[u8], plaintext: &str) -> Result<Stri
     getrandom::fill(&mut nonce_bytes).map_err(|e| format!("nonce rng: {}", e))?;
     let ciphertext = cipher
         .encrypt(
-            Nonce::from_slice(&nonce_bytes),
+            &Nonce::from(nonce_bytes),
             Payload { msg: plaintext.as_bytes(), aad },
         )
         .map_err(|e| format!("encrypt: {}", e))?;
@@ -154,14 +154,14 @@ pub fn decrypt_value(key: &[u8; 32], aad: &[u8], blob: &str) -> Result<String, S
     }
     let (nonce_bytes, ciphertext) = raw.split_at(12);
     let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| format!("cipher init: {}", e))?;
-    let nonce = Nonce::from_slice(nonce_bytes);
+    let nonce = Nonce::try_from(nonce_bytes).map_err(|e| format!("nonce: {}", e))?;
     let plain = if bound {
         cipher
-            .decrypt(nonce, Payload { msg: ciphertext, aad })
+            .decrypt(&nonce, Payload { msg: ciphertext, aad })
             .map_err(|_| SEALED_ELSEWHERE.to_string())?
     } else {
         cipher
-            .decrypt(nonce, ciphertext)
+            .decrypt(&nonce, ciphertext)
             .map_err(|e| format!("decrypt: {}", e))?
     };
     String::from_utf8(plain).map_err(|e| format!("utf8: {}", e))


### PR DESCRIPTION
## What this changes

Expands native library search paths in `.cargo/config.toml` and `crates/duckdb-engine/build.rs` to support non-Debian Linux distributions when linking static unixODBC (`teradata-static`), and resolves all deprecation and unused code warnings across `duckle-secrets`, `duckle-duckdb-engine`, and `duckle-runner`.

## Related issue

Refs #131

## Type

- [x] Bug fix
- [ ] New feature (connector / transform / sink)
- [ ] Performance
- [ ] Docs
- [x] Refactor / internal

## Checklist

- [x] `cargo fmt` and `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] `cargo test --workspace` passes (engine tests need `DUCKLE_DUCKDB_BIN` set - see CONTRIBUTING.md)
- [ ] `npm --prefix frontend run lint` passes (if the frontend changed)
- [x] Commits are small with imperative subject lines
- [x] No code ported from incompatibly licensed sources

## Notes for reviewers

- Linux distributions outside Debian/Ubuntu (like Arch or Fedora) or environments where static libraries (`libodbc.a`, `libltdl.a`) reside in `~/.local/lib` or `/usr/local/lib` can now build `duckle-runner` with `features = ["teradata-static"]` without manual environment variable workarounds.
- Deprecated APIs (`Nonce::from_slice`, `from_avro_datum`, `Attribute::unescape_value`, and `set_max_row_group_size`) were updated to their modern replacements.