### PR TITLE
fix(policy): block extension downloads in restricted runs

### DIFF
--- a/crates/duckdb-engine/src/connectors.rs
+++ b/crates/duckdb-engine/src/connectors.rs
@@ -12250,7 +12250,10 @@ impl DuckdbEngine {
         *ANSWER.get_or_init(|| {
             self.run(
                 None,
-                "INSTALL arrow FROM community; LOAD arrow; SELECT 1;",
+                &format!(
+                    "{}SELECT 1;",
+                    crate::policy::duckdb_extension_prelude("arrow", true)
+                ),
                 true,
             )
             .is_ok()
@@ -16557,7 +16560,8 @@ impl DuckdbEngine {
             .map(|d| format!(", DATA_PATH '{}'", d.replace('\\', "/").replace('\'', "''")))
             .unwrap_or_default();
         let attach = format!(
-            "INSTALL ducklake; LOAD ducklake; ATTACH 'ducklake:{}' AS duckle_src (READ_ONLY{}); ",
+            "{}ATTACH 'ducklake:{}' AS duckle_src (READ_ONLY{}); ",
+            crate::policy::duckdb_extension_prelude("ducklake", false),
             path, data_path
         );
         let node_q = plan::quote_ident(&spec.node_id);
@@ -17260,10 +17264,11 @@ impl DuckdbEngine {
         // Phase 1: stage upstream into a named table that the next CLI
         // invocation will see.
         let stage_sql = format!(
-            "{secret}INSTALL fts; LOAD fts; \
+            "{secret}{fts} \
              DROP TABLE IF EXISTS {staging}; \
              CREATE TABLE {staging} AS SELECT * FROM {upstream};",
             secret = secret_prefix,
+            fts = crate::policy::duckdb_extension_prelude("fts", false),
             staging = staging,
             upstream = upstream,
         );
@@ -17289,12 +17294,13 @@ impl DuckdbEngine {
             None => String::new(),
         };
         let index_sql = format!(
-            "{secret}INSTALL fts; LOAD fts; \
+            "{secret}{fts} \
              PRAGMA create_fts_index('{staging_raw}', '{id_col}', {text_args}); \
              CREATE OR REPLACE TABLE {node} AS \
                SELECT *, {match_expr} AS {output_q} FROM {staging} \
                WHERE {match_expr} IS NOT NULL{order_limit};",
             secret = secret_prefix,
+            fts = crate::policy::duckdb_extension_prelude("fts", false),
             staging_raw = spec.staging_table.replace('\'', "''"),
             id_col = spec.id_col.replace('\'', "''"),
             text_args = text_args,

--- a/crates/duckdb-engine/src/lib.rs
+++ b/crates/duckdb-engine/src/lib.rs
@@ -547,14 +547,7 @@ impl DuckdbEngine {
     /// stdout. Cancellation-aware: polls the child and kills it if a
     /// cancel was requested.
     fn run(&self, db: Option<&Path>, sql: &str, json: bool) -> Result<String, EngineError> {
-        if crate::policy::duckdb_external_io_denied()
-            && crate::policy::contains_explicit_install(sql)
-        {
-            return Err(EngineError::Query(
-                "policy: DuckDB INSTALL is disabled in restricted-network mode; pre-install the extension and use LOAD"
-                    .into(),
-            ));
-        }
+        crate::policy::refuse_install_if_restricted(sql).map_err(EngineError::Query)?;
         if !self.bin.exists() {
             return Err(EngineError::Config(format!(
                 "DuckDB engine isn't installed (expected at {}). Open Setup to install it.",
@@ -3226,6 +3219,15 @@ impl DuckdbEngine {
             }
         }
 
+        // The batched executor is its own CLI entry point: it never calls
+        // `run()`, so the guard there covered the per-stage path and left the
+        // DEFAULT one open. A pure-SQL stage carries its body verbatim, so an
+        // INSTALL in one really did download an extension under an enforcing
+        // policy until this line existed.
+        if let Err(e) = crate::policy::refuse_install_if_restricted(&batched_sql) {
+            return RunResult::failed(total_start, e);
+        }
+
         let mut cmd = std::process::Command::new(&self.bin);
         cmd.arg(db_path);
         // Same as run(): open the throwaway run-db at v1.5.0 so GEOMETRY CRS
@@ -4972,6 +4974,9 @@ pub(crate) fn write_arrayrows_to(
 /// the process env is empty (tests, embedded hosts).
 pub(crate) fn apply_duckdb_sql(bin: &Path, db: &Path, sql: &str) -> Result<(), EngineError> {
     use std::process::Command;
+    // The third CLI entry point, reached from the connectors and the output
+    // cache. Same reason as the other two.
+    crate::policy::refuse_install_if_restricted(sql).map_err(EngineError::Query)?;
     let mut cmd = Command::new(bin);
     #[cfg(windows)]
     {

--- a/crates/duckdb-engine/src/lib.rs
+++ b/crates/duckdb-engine/src/lib.rs
@@ -547,6 +547,14 @@ impl DuckdbEngine {
     /// stdout. Cancellation-aware: polls the child and kills it if a
     /// cancel was requested.
     fn run(&self, db: Option<&Path>, sql: &str, json: bool) -> Result<String, EngineError> {
+        if crate::policy::duckdb_external_io_denied()
+            && crate::policy::contains_explicit_install(sql)
+        {
+            return Err(EngineError::Query(
+                "policy: DuckDB INSTALL is disabled in restricted-network mode; pre-install the extension and use LOAD"
+                    .into(),
+            ));
+        }
         if !self.bin.exists() {
             return Err(EngineError::Config(format!(
                 "DuckDB engine isn't installed (expected at {}). Open Setup to install it.",
@@ -1276,7 +1284,7 @@ impl DuckdbEngine {
             p.push(' ');
         }
         if format == "azureblob" {
-            p.push_str("INSTALL azure; LOAD azure; ");
+            p.push_str(&crate::policy::duckdb_extension_prelude("azure", false));
         }
         // What the RUN path loads for this component, asked OF the run path
         // rather than kept as a second list here.
@@ -7940,7 +7948,7 @@ mod oracle_insert_all_tests {
 
 #[cfg(test)]
 mod resource_pragma_tests {
-    use super::resource_pragmas;
+    use super::{resource_pragmas, DuckdbEngine};
 
     fn guard() -> std::sync::MutexGuard<'static, ()> {
         static L: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -7982,7 +7990,6 @@ network:
 
         let p = resource_pragmas(None, None);
 
-        std::env::remove_var("DUCKLE_POLICY_FILE");
         assert!(
             p.contains("disabled_filesystems"),
             "DuckDB could still read https:// itself, outside the allowlist: {p}"
@@ -7991,6 +7998,18 @@ network:
             p.contains("allow_community_extensions=false"),
             "an extension carrying its own network code would still load: {p}"
         );
+
+        assert_eq!(
+            crate::policy::duckdb_extension_prelude("httpfs", false),
+            "LOAD httpfs; ",
+            "restricted runs must never emit an extension download"
+        );
+        let err = DuckdbEngine::new("missing-duckdb".into())
+            .run(None, "INSTALL httpfs;", false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("INSTALL is disabled"), "raw install escaped: {err}");
+        std::env::remove_var("DUCKLE_POLICY_FILE");
     }
 
     /// And an environment with no policy is not hardened, so an ordinary local

--- a/crates/duckdb-engine/src/lib.rs
+++ b/crates/duckdb-engine/src/lib.rs
@@ -8003,28 +8003,36 @@ network:
         .unwrap();
         std::env::set_var("DUCKLE_POLICY_FILE", &pol);
 
-        let p = resource_pragmas(None, None);
-
-        assert!(
-            p.contains("disabled_filesystems"),
-            "DuckDB could still read https:// itself, outside the allowlist: {p}"
-        );
-        assert!(
-            p.contains("allow_community_extensions=false"),
-            "an extension carrying its own network code would still load: {p}"
-        );
-
-        assert_eq!(
-            crate::policy::duckdb_extension_prelude("httpfs", false),
-            "LOAD httpfs; ",
-            "restricted runs must never emit an extension download"
-        );
-        let err = DuckdbEngine::new("missing-duckdb".into())
+        // Everything that reads the policy happens here, and the variable is
+        // cleared before a single assertion runs.
+        //
+        // Not for tidiness: `assert!` panics, so a removal placed after the
+        // assertions is SKIPPED by the first one that fails, and
+        // DUCKLE_POLICY_FILE then stays set for the rest of the process. This
+        // module's mutex does not help, because the other two thousand tests
+        // are not holding it. One failing assertion here would turn into
+        // unrelated failures elsewhere, which is a bad way to find out.
+        let pragmas = resource_pragmas(None, None);
+        let prelude = crate::policy::duckdb_extension_prelude("httpfs", false);
+        let refusal = DuckdbEngine::new("missing-duckdb".into())
             .run(None, "INSTALL httpfs;", false)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("INSTALL is disabled"), "raw install escaped: {err}");
         std::env::remove_var("DUCKLE_POLICY_FILE");
+
+        assert!(
+            pragmas.contains("disabled_filesystems"),
+            "DuckDB could still read https:// itself, outside the allowlist: {pragmas}"
+        );
+        assert!(
+            pragmas.contains("allow_community_extensions=false"),
+            "an extension carrying its own network code would still load: {pragmas}"
+        );
+        assert_eq!(
+            prelude, "LOAD httpfs; ",
+            "restricted runs must never emit an extension download"
+        );
+        assert!(refusal.contains("INSTALL is disabled"), "raw install escaped: {refusal}");
     }
 
     /// And an environment with no policy is not hardened, so an ordinary local

--- a/crates/duckdb-engine/src/plan/builders.rs
+++ b/crates/duckdb-engine/src/plan/builders.rs
@@ -5841,14 +5841,14 @@ pub(crate) fn attach_prelude(component_id: &str, props: &JsonValue) -> String {
         let auto = string_prop(props, "sql").map(|s| references_spatial(&s)).unwrap_or(false);
         let want_spatial = opt_in || auto;
         if want_spatial {
-            prelude.push_str("INSTALL spatial; LOAD spatial; ");
+            prelude.push_str(&crate::policy::duckdb_extension_prelude("spatial", false));
         }
         for ext in parse_extension_names(props.get("loadExtensions")) {
             // spatial may already be queued above; don't load it twice.
             if ext == "spatial" && want_spatial {
                 continue;
             }
-            prelude.push_str(&format!("INSTALL {ext}; LOAD {ext}; "));
+            prelude.push_str(&crate::policy::duckdb_extension_prelude(&ext, false));
         }
         return prelude;
     }
@@ -5900,7 +5900,7 @@ pub(crate) fn attach_prelude(component_id: &str, props: &JsonValue) -> String {
         // is_secret_prop_key and resolved from ${ENV:...} at run time, like every
         // other connector secret.
         "src.huggingface" => {
-            let mut prelude = String::from("INSTALL httpfs; LOAD httpfs; ");
+            let mut prelude = crate::policy::duckdb_extension_prelude("httpfs", false);
             if let Some(token) = string_prop(props, "token").filter(|s| !s.trim().is_empty()) {
                 prelude.push_str(&format!(
                     "CREATE OR REPLACE SECRET duckle_hf (TYPE HUGGINGFACE, TOKEN '{}'); ",
@@ -5937,7 +5937,10 @@ pub(crate) fn attach_prelude(component_id: &str, props: &JsonValue) -> String {
         // Create Geometry (#190) builds points/geoms and pins lon/lat order so
         // ST_Point(x, y) reads x as longitude, matching the GeoParquet default.
         | "xf.geo.create" => {
-            return "INSTALL spatial; LOAD spatial; SET geometry_always_xy = true; ".into();
+            return format!(
+                "{}SET geometry_always_xy = true; ",
+                crate::policy::duckdb_extension_prelude("spatial", false)
+            );
         }
         "src.spatial"
         | "src.gdb"
@@ -5954,12 +5957,12 @@ pub(crate) fn attach_prelude(component_id: &str, props: &JsonValue) -> String {
         | "qa.geomvalidate"
         | "qa.geomrepair"
         | "qa.geomempty" => {
-            return "INSTALL spatial; LOAD spatial; ".into();
+            return crate::policy::duckdb_extension_prelude("spatial", false);
         }
         // inet is a small built-in extension. INSTALL is a no-op once
         // the extension is bundled, but keeping it explicit means a
         // fresh CLI cache still works without the first-launch fetch.
-        "xf.ip.parse" => return "INSTALL inet; LOAD inet; ".into(),
+        "xf.ip.parse" => return crate::policy::duckdb_extension_prelude("inet", false),
         _ => {}
     }
     let db = match string_prop(props, "database").filter(|s| !s.is_empty()) {
@@ -6030,7 +6033,8 @@ fn mssql_attach(props: &JsonValue) -> String {
         .map(|n| n.min(1000))
         .unwrap_or(1000);
     format!(
-        "INSTALL mssql FROM community; LOAD mssql; SET mssql_insert_batch_size = {}; ATTACH '{}' AS duckle_dst (TYPE mssql); ",
+        "{}SET mssql_insert_batch_size = {}; ATTACH '{}' AS duckle_dst (TYPE mssql); ",
+        crate::policy::duckdb_extension_prelude("mssql", true),
         batch,
         sql_escape(&connstr)
     )
@@ -6669,7 +6673,8 @@ pub(crate) fn ducklake_attach(props: &JsonValue, read_only: bool) -> String {
         format!(" ({})", opts.join(", "))
     };
     format!(
-        "INSTALL ducklake; LOAD ducklake; ATTACH 'ducklake:{}' AS {}{}; ",
+        "{}ATTACH 'ducklake:{}' AS {}{}; ",
+        crate::policy::duckdb_extension_prelude("ducklake", false),
         sql_escape(&path),
         alias,
         tail
@@ -6705,7 +6710,8 @@ pub(crate) fn bigquery_attach(props: &JsonValue, read_only: bool) -> String {
     // INSTALL/LOAD the community extension. The community: tag tells
     // DuckDB to fetch from the community-extensions repo.
     format!(
-        "INSTALL bigquery FROM community; LOAD bigquery; ATTACH '{}' AS {} (TYPE bigquery{}); ",
+        "{}ATTACH '{}' AS {} (TYPE bigquery{}); ",
+        crate::policy::duckdb_extension_prelude("bigquery", true),
         sql_escape(&attach_target), alias, mode
     )
 }
@@ -6728,7 +6734,8 @@ pub(crate) fn md_attach(props: &JsonValue, read_only: bool) -> String {
     // MotherDuck falls back to the MOTHERDUCK_TOKEN environment variable.
     match token {
         Some(t) => format!(
-            "INSTALL motherduck; LOAD motherduck; SET motherduck_token='{}'; ATTACH 'md:{}' AS {}{}; ",
+            "{}SET motherduck_token='{}'; ATTACH 'md:{}' AS {}{}; ",
+            crate::policy::duckdb_extension_prelude("motherduck", false),
             sql_escape(&t),
             sql_escape(&db),
             alias,
@@ -6857,7 +6864,8 @@ pub(crate) fn build_spatial_sink(props: &JsonValue, from_view: &str) -> String {
                 // loads it: a GEOMETRY read back from a plain Parquet file does not
                 // taint this stage, and ST_Hilbert would then fail at write time,
                 // after the whole pipeline had already run.
-                "INSTALL spatial; LOAD spatial; COPY (SELECT * FROM {} {}) TO '{}' (FORMAT PARQUET)",
+                "{}COPY (SELECT * FROM {} {}) TO '{}' (FORMAT PARQUET)",
+                crate::policy::duckdb_extension_prelude("spatial", false),
                 quote_ident(from_view),
                 order_by,
                 sql_escape(&path)
@@ -9879,7 +9887,8 @@ pub(crate) fn build_parquet_sink(props: &JsonValue, from_view: &str) -> String {
             // taints this stage, but a GEOMETRY read back from a plain Parquet
             // file does not, and ST_Hilbert would then fail at write time -
             // after the whole pipeline had already run.
-            "INSTALL spatial; LOAD spatial; COPY (SELECT * FROM ({}) {}) TO '{}' ({})",
+            "{}COPY (SELECT * FROM ({}) {}) TO '{}' ({})",
+            crate::policy::duckdb_extension_prelude("spatial", false),
             source,
             order_by,
             sql_escape(&path),

--- a/crates/duckdb-engine/src/plan/mod.rs
+++ b/crates/duckdb-engine/src/plan/mod.rs
@@ -1398,7 +1398,10 @@ fn compile_impl(pipeline: &PipelineDoc, allow_view_upgrade: bool) -> Result<Comp
         }
         for s in stages.iter_mut() {
             if geom_tainted.contains(&s.node_id) && !s.sql.contains("LOAD spatial") {
-                s.sql.insert_str(0, "INSTALL spatial; LOAD spatial; ");
+                s.sql.insert_str(
+                    0,
+                    &crate::policy::duckdb_extension_prelude("spatial", false),
+                );
             }
         }
     }

--- a/crates/duckdb-engine/src/policy.rs
+++ b/crates/duckdb-engine/src/policy.rs
@@ -462,16 +462,93 @@ fn network_allowlist() -> Option<BTreeSet<String>> {
 ///   extensions that are already on disk, and turning it off breaks ordinary
 ///   local queries.
 ///
-/// Known residual: an explicit `INSTALL` of a core extension still succeeds,
-/// because extension download does not go through the disabled filesystems.
-/// Naming that extension's filesystem above is what keeps it from reaching
-/// anything.
+/// Explicit `INSTALL` is handled separately: generated preludes become
+/// `LOAD`-only and the execution boundary rejects raw `INSTALL` SQL.
 pub const DUCKDB_OFF_NETWORK: &str = concat!(
     "SET disabled_filesystems=",
     "'HTTPFileSystem,S3FileSystem,AzureBlobStorageFileSystem,GCSFileSystem';\n",
     "SET allow_community_extensions=false;\n",
     "SET autoinstall_known_extensions=false;\n",
 );
+
+/// Load an extension without allowing a restricted run to download it.
+pub fn duckdb_extension_prelude(name: &str, community: bool) -> String {
+    if duckdb_external_io_denied() {
+        return format!("LOAD {name}; ");
+    }
+    if community {
+        format!("INSTALL {name} FROM community; LOAD {name}; ")
+    } else {
+        format!("INSTALL {name}; LOAD {name}; ")
+    }
+}
+
+/// Detect the SQL command that can download an extension, ignoring quoted
+/// strings and comments. A restricted run must reject it at the one boundary
+/// shared by stage, probe, and batched execution.
+pub fn contains_explicit_install(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        i += 1;
+                        if i < bytes.len() && bytes[i] == b'\'' {
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'"' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'"' {
+                        i += 1;
+                        if i < bytes.len() && bytes[i] == b'"' {
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'-' if bytes.get(i + 1) == Some(&b'-') => {
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(bytes.len());
+            }
+            c if c.is_ascii_alphabetic() || c == b'_' => {
+                let start = i;
+                i += 1;
+                while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                    i += 1;
+                }
+                if bytes[start..i].eq_ignore_ascii_case(b"install") {
+                    return true;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    false
+}
 
 /// Must DuckDB be taken off the network for this run?
 ///
@@ -832,6 +909,15 @@ mod tests {
         }
         p.narrow_with(layer, "test");
         p
+    }
+
+    #[test]
+    fn install_detector_ignores_text_and_comments() {
+        assert!(contains_explicit_install("SET x=1; INSTALL httpfs;"));
+        assert!(contains_explicit_install("/* generated */\nInStAlL spatial;"));
+        assert!(!contains_explicit_install("SELECT 'INSTALL httpfs';"));
+        assert!(!contains_explicit_install("-- INSTALL httpfs;\nSELECT 1;"));
+        assert!(!contains_explicit_install("SELECT installer FROM users;"));
     }
 
     /// The headline case: an agent writes a pipeline that would write to

--- a/crates/duckdb-engine/src/policy.rs
+++ b/crates/duckdb-engine/src/policy.rs
@@ -483,12 +483,31 @@ pub fn duckdb_extension_prelude(name: &str, community: bool) -> String {
     }
 }
 
+/// Refuse SQL that would download an extension, where the policy forbids it.
+///
+/// Called from EVERY place that hands SQL to the CLI, because there is no one
+/// boundary they share: `run()` covers the per-stage path, `execute_batched`
+/// spawns its own child, and `apply_duckdb_sql` is a third. A guard in `run()`
+/// alone let the DEFAULT path through - measured, as a real download from
+/// extensions.duckdb.org under an enforcing policy.
+pub fn refuse_install_if_restricted(sql: &str) -> Result<(), String> {
+    match duckdb_external_io_denied() && contains_explicit_install(sql) {
+        true => Err("policy: DuckDB INSTALL is disabled in restricted-network mode; \
+                     pre-install the extension and use LOAD"
+            .into()),
+        false => Ok(()),
+    }
+}
+
 /// Detect the SQL command that can download an extension, ignoring quoted
-/// strings and comments. A restricted run must reject it at the one boundary
-/// shared by stage, probe, and batched execution.
+/// strings, dollar-quoted bodies and comments, and looking only where a
+/// statement starts.
 pub fn contains_explicit_install(sql: &str) -> bool {
     let bytes = sql.as_bytes();
     let mut i = 0;
+    // INSTALL can only be the first word of a statement, so that is the only
+    // place worth looking. Starts true: the very beginning is a statement start.
+    let mut at_statement_start = true;
     while i < bytes.len() {
         match bytes[i] {
             b'\'' => {
@@ -521,11 +540,16 @@ pub fn contains_explicit_install(sql: &str) -> bool {
                     }
                 }
             }
+            // A comment is whitespace to the parser, so it does not move a
+            // statement off its opening position: `/* generated */ INSTALL x;`
+            // is still an INSTALL, and that is a real shape here because these
+            // preludes are generated with a provenance comment in front.
             b'-' if bytes.get(i + 1) == Some(&b'-') => {
                 i += 2;
                 while i < bytes.len() && bytes[i] != b'\n' {
                     i += 1;
                 }
+                continue;
             }
             b'/' if bytes.get(i + 1) == Some(&b'*') => {
                 i += 2;
@@ -533,21 +557,85 @@ pub fn contains_explicit_install(sql: &str) -> bool {
                     i += 1;
                 }
                 i = (i + 2).min(bytes.len());
+                continue;
             }
+            // A dollar-quoted body is a string. Without this arm an apostrophe
+            // inside `$$...$$` opened the single-quote branch, which found no
+            // close, consumed to end of input, and hid every statement after
+            // it - so the detector answered "no" to a payload that then
+            // downloaded an extension. A lone `$` (a positional parameter) is
+            // not a dollar quote and must not swallow anything.
+            b'$' => match dollar_quote_tag(bytes, i) {
+                Some(tag_len) => {
+                    let tag = &bytes[i..i + tag_len];
+                    i += tag_len;
+                    while i < bytes.len() {
+                        if bytes[i] == b'$' && bytes[i..].starts_with(tag) {
+                            i += tag_len;
+                            break;
+                        }
+                        i += 1;
+                    }
+                }
+                None => i += 1,
+            },
             c if c.is_ascii_alphabetic() || c == b'_' => {
                 let start = i;
                 i += 1;
                 while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
                     i += 1;
                 }
-                if bytes[start..i].eq_ignore_ascii_case(b"install") {
+                let word = &bytes[start..i];
+                // Only where a statement STARTS. `install` is an unreserved
+                // keyword in the pinned DuckDB, so it is a legal identifier:
+                // `SELECT 1 AS install` is ordinary SQL and refusing it broke
+                // real queries, and only under a policy.
+                if at_statement_start && word.eq_ignore_ascii_case(b"install") {
                     return true;
                 }
+                // `FORCE INSTALL x` is the same command in two words, so FORCE
+                // does not end the statement's opening position.
+                at_statement_start = at_statement_start && word.eq_ignore_ascii_case(b"force");
+                continue;
+            }
+            b';' => {
+                at_statement_start = true;
+                i += 1;
+                continue;
+            }
+            c if c.is_ascii_whitespace() => {
+                i += 1;
+                continue;
             }
             _ => i += 1,
         }
+        // Anything that is not whitespace, a comment, a `;` or the opening word
+        // of a statement means we are inside one.
+        at_statement_start = false;
     }
     false
+}
+
+/// The length of a dollar-quote opener at `at` (`$$` or `$tag$`), or None when
+/// this `$` opens nothing - a positional parameter like `$1`, or a bare `$`.
+///
+/// A tag is what DuckDB accepts between the dollars: letters, digits and
+/// underscores, not starting with a digit.
+fn dollar_quote_tag(bytes: &[u8], at: usize) -> Option<usize> {
+    let mut j = at + 1;
+    if bytes.get(j) == Some(&b'$') {
+        return Some(2);
+    }
+    if bytes.get(j).is_some_and(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    while bytes.get(j).is_some_and(|c| c.is_ascii_alphanumeric() || *c == b'_') {
+        j += 1;
+    }
+    match bytes.get(j) {
+        Some(&b'$') if j > at + 1 => Some(j - at + 1),
+        _ => None,
+    }
 }
 
 /// Must DuckDB be taken off the network for this run?
@@ -918,6 +1006,48 @@ mod tests {
         assert!(!contains_explicit_install("SELECT 'INSTALL httpfs';"));
         assert!(!contains_explicit_install("-- INSTALL httpfs;\nSELECT 1;"));
         assert!(!contains_explicit_install("SELECT installer FROM users;"));
+    }
+
+    /// A dollar-quoted body is a string, and the scanner has to know that.
+    ///
+    /// Without a `$` arm, an apostrophe inside `$$...$$` opens the single-quote
+    /// branch, which finds no closing quote and consumes to end of input - so
+    /// every statement after it is invisible and the detector answers "no".
+    /// Reproduced end to end against the pinned CLI as a real download from
+    /// extensions.duckdb.org under an enforcing policy, so this is the guard
+    /// failing open rather than a near-miss.
+    #[test]
+    fn a_dollar_quoted_string_does_not_hide_what_follows_it() {
+        assert!(
+            contains_explicit_install("SELECT $$it's$$ AS a; INSTALL httpfs;"),
+            "an apostrophe inside $$...$$ desynced the scanner"
+        );
+        assert!(
+            contains_explicit_install("SELECT $tag$it's$tag$ AS a; INSTALL httpfs;"),
+            "a tagged dollar quote desynced the scanner"
+        );
+        // The other direction: the word inside the literal is text, not a command.
+        assert!(!contains_explicit_install("SELECT $$INSTALL httpfs$$ AS a;"));
+        assert!(!contains_explicit_install("SELECT $q$INSTALL httpfs$q$ AS a;"));
+        // A lone `$` is not a dollar quote. A positional parameter must not
+        // swallow the rest of the statement.
+        assert!(contains_explicit_install("SELECT $1; INSTALL httpfs;"));
+    }
+
+    /// `install` is an UNRESERVED keyword in the pinned DuckDB 1.5.4, so it is a
+    /// legal identifier. Refusing it wherever it appears fails ordinary SQL, and
+    /// only under a policy, which is a confusing way to find out.
+    #[test]
+    fn the_detector_only_looks_where_a_statement_starts() {
+        assert!(!contains_explicit_install("SELECT 1 AS install;"));
+        assert!(!contains_explicit_install("SELECT install FROM t;"));
+        assert!(!contains_explicit_install("CREATE VIEW v AS SELECT 1 AS install;"));
+        // Still caught where it really is the command, including the two-word
+        // form DuckDB accepts.
+        assert!(contains_explicit_install("INSTALL httpfs;"));
+        assert!(contains_explicit_install("   install httpfs;"));
+        assert!(contains_explicit_install("FORCE INSTALL httpfs;"));
+        assert!(contains_explicit_install("SELECT 1; force install httpfs;"));
     }
 
     /// The headline case: an agent writes a pipeline that would write to


### PR DESCRIPTION
Fixes #290

Restricted-network mode already disables DuckDB remote filesystems and community extensions, but explicit `INSTALL` could still download an extension. This change:

- emits `LOAD`-only preludes when the policy denies DuckDB external I/O;
- rejects raw `INSTALL` SQL at the shared DuckDB execution boundary;
- covers stage, probe, batched, and connector-generated extension paths;
- preserves local file access.

Tests:
- `cargo test -p duckle-duckdb-engine install_detector_ignores_text_and_comments`
- `cargo test -p duckle-duckdb-engine a_restricted_network_takes_duckdb_off_the_network_too`
- `cargo test -p duckle-duckdb-engine attach_prelude`
- `cargo test -p duckle-duckdb-engine resource_pragma_tests::no_policy_leaves_duckdb_on_the_network`