### PR TITLE
feat(xsd): add audited parser-contract acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2244,8 +2244,14 @@ seen, in `.duckle/xsd_contracts`:
 | `xsdChangePolicy` | on a change |
 |---|---|
 | `warn` (default) | says so once, accepts the new set, run continues |
-| `fail` | refuses the run until you accept it by deleting the line |
+| `fail` | refuses the run until you accept it with `duckle-runner xsd accept` |
 | `allow` | does not look |
+
+Inspect accepted contracts with `duckle-runner xsd list --workspace <dir>`. To
+approve the fingerprint printed by a failed run, use
+`duckle-runner xsd accept --workspace <dir> --uri <schema-uri> --fingerprint <sha256> --reason <why>`.
+The acceptance is written to the audit log with the actor, old and new
+fingerprints, and reason.
 
 The fingerprint covers **every** document in the closure, not the root, because
 an `xs:include` three levels down decides a column's type just as much - a root

--- a/crates/duckdb-engine/src/connectors.rs
+++ b/crates/duckdb-engine/src/connectors.rs
@@ -20743,7 +20743,7 @@ pub(crate) fn xsd_contract_fingerprint(docs: &[(String, String)]) -> String {
 /// behaviour rather than refusing every run.
 pub(crate) fn xsd_contracts_path() -> Option<std::path::PathBuf> {
     let ws = std::env::var("DUCKLE_WORKSPACE").ok().filter(|s| !s.is_empty())?;
-    Some(std::path::Path::new(&ws).join(".duckle").join("xsd_contracts"))
+    Some(crate::xsd_contract::path(std::path::Path::new(&ws)))
 }
 
 /// The contract already accepted for this schema root, if any.
@@ -20752,40 +20752,14 @@ pub(crate) fn xsd_contracts_path() -> Option<std::path::PathBuf> {
 /// can be deleted by hand - which is the whole escape hatch when a publisher
 /// legitimately reissues a schema.
 pub(crate) fn read_xsd_contract(path: &std::path::Path, uri: &str) -> Option<String> {
-    let text = std::fs::read_to_string(path).ok()?;
-    text.lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with('#'))
-        .find_map(|l| {
-            let (u, fp) = l.split_once(char::is_whitespace)?;
-            (u == uri).then(|| fp.trim().to_string())
-        })
+    crate::xsd_contract::accepted(path, uri)
 }
 
 /// Accept a contract. Best-effort: a workspace that cannot be written still
 /// runs, because failing a run over bookkeeping would be a worse failure than
 /// the one being prevented.
 fn record_xsd_contract(path: &std::path::Path, uri: &str, fingerprint: &str) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let existing = std::fs::read_to_string(path).unwrap_or_default();
-    // Replace any line for this uri rather than appending a second one: unlike
-    // a host behind a load balancer, a schema root has exactly one accepted
-    // contract at a time, and two lines would make "which one held?" ambiguous.
-    let mut out: Vec<String> = existing
-        .lines()
-        .filter(|l| {
-            let t = l.trim();
-            if t.is_empty() || t.starts_with('#') {
-                return true;
-            }
-            t.split_once(char::is_whitespace).map(|(u, _)| u != uri).unwrap_or(true)
-        })
-        .map(str::to_string)
-        .collect();
-    out.push(format!("{uri} {fingerprint}"));
-    let _ = std::fs::write(path, out.join("\n") + "\n");
+    let _ = crate::xsd_contract::accept(path, uri, fingerprint);
 }
 
 /// #315: hold the parser contract still, or say plainly that it moved.

--- a/crates/duckdb-engine/src/lib.rs
+++ b/crates/duckdb-engine/src/lib.rs
@@ -84,6 +84,7 @@ pub mod trust;
 pub mod tls;
 pub mod watermark;
 pub mod xsd;
+pub mod xsd_contract;
 mod connectors;
 pub use connectors::remote_fingerprint;
 mod run_log;

--- a/crates/duckdb-engine/src/xsd_contract.rs
+++ b/crates/duckdb-engine/src/xsd_contract.rs
@@ -1,0 +1,112 @@
+//! The accepted XSD parser-contract store (#315).
+//!
+//! The connector and the headless CLI must use the same file format. Keeping
+//! the small read/replace operation here prevents an operator accepting a
+//! contract through one surface from being invisible to another.
+
+use std::path::{Path, PathBuf};
+
+/// Where accepted parser contracts live for a workspace.
+pub fn path(workspace: &Path) -> PathBuf {
+    workspace.join(".duckle").join("xsd_contracts")
+}
+
+/// Return every well-formed accepted contract, in file order.
+pub fn list(path: &Path) -> Result<Vec<(String, String)>, String> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(format!("{}: {e}", path.display())),
+    };
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| {
+            let (uri, fingerprint) = line.split_once(char::is_whitespace)?;
+            Some((uri.to_string(), fingerprint.trim().to_string()))
+        })
+        .collect())
+}
+
+/// Return the accepted fingerprint for one schema root.
+pub fn accepted(path: &Path, uri: &str) -> Option<String> {
+    list(path)
+        .ok()?
+        .into_iter()
+        .find_map(|(known_uri, fingerprint)| (known_uri == uri).then_some(fingerprint))
+}
+
+/// Replace one URI's accepted fingerprint, preserving comments and other URIs.
+///
+/// The old value is returned for the audit record. A missing value means this
+/// is the first explicit acceptance for the URI.
+pub fn accept(path: &Path, uri: &str, fingerprint: &str) -> Result<Option<String>, String> {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(format!("{}: {e}", path.display())),
+    };
+    let previous = existing.lines().find_map(|line| {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            return None;
+        }
+        let (known_uri, known_fingerprint) = trimmed.split_once(char::is_whitespace)?;
+        (known_uri == uri).then_some(known_fingerprint.trim().to_string())
+    });
+    let mut lines: Vec<String> = existing
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return true;
+            }
+            trimmed
+                .split_once(char::is_whitespace)
+                .map(|(known_uri, _)| known_uri != uri)
+                .unwrap_or(true)
+        })
+        .map(str::to_string)
+        .collect();
+    lines.push(format!("{uri} {fingerprint}"));
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
+    }
+    std::fs::write(path, lines.join("\n") + "\n")
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(previous)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_one_uri_without_disturbing_comments_or_other_contracts() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join(".duckle/xsd_contracts");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "# keep\na.xsd old\nb.xsd other\n").unwrap();
+
+        assert_eq!(accept(&file, "a.xsd", "new").unwrap(), Some("old".into()));
+        assert_eq!(
+            list(&file).unwrap(),
+            vec![
+                ("b.xsd".into(), "other".into()),
+                ("a.xsd".into(), "new".into())
+            ]
+        );
+        assert!(std::fs::read_to_string(file)
+            .unwrap()
+            .starts_with("# keep\n"));
+    }
+
+    #[test]
+    fn a_missing_store_is_an_empty_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("missing");
+        assert!(list(&file).unwrap().is_empty());
+        assert_eq!(accepted(&file, "a.xsd"), None);
+    }
+}

--- a/crates/duckle-mcp/catalog.json
+++ b/crates/duckle-mcp/catalog.json
@@ -2357,7 +2357,7 @@
                     "value": "allow"
                   }
                 ],
-                "description": "The whole resolved schema set, including anything it imports, is remembered the first time it is read. If it later changes, the columns this feed is parsed into may change with it. Warn accepts the new set and says so once. Fail refuses the run until you accept the change by deleting the line from .duckle/xsd_contracts. Ignore does not look."
+                "description": "The whole resolved schema set, including anything it imports, is remembered the first time it is read. If it later changes, the columns this feed is parsed into may change with it. Warn accepts the new set and says so once. Fail refuses the run until you accept it with duckle-runner xsd accept. Ignore does not look."
               }
             ]
           },

--- a/crates/duckle-runner/src/main.rs
+++ b/crates/duckle-runner/src/main.rs
@@ -54,6 +54,7 @@ mod python;
 mod selfextract;
 mod work;
 mod sequence_cmd;
+mod xsd_cmd;
 mod serve;
 
 const USAGE: &str = "\
@@ -69,6 +70,7 @@ USAGE:
     duckle-runner sequence <status|plan|apply> <file.json>
     duckle-runner deliveries <status|retry>  (#325 subscription pump ledger)
     duckle-runner python <check|prepare>   (the workspace's Python environment)
+    duckle-runner xsd <list|accept>       (accepted XML parser contracts)
 
 TEST:
     Run a pipeline against a fixed input and assert the rows out of one node.
@@ -2128,6 +2130,10 @@ fn main() -> ExitCode {
                 ExitCode::from(2)
             }
         };
+    }
+    // `xsd` -> inspect and explicitly accept a changed parser contract (#315).
+    if std::env::args().nth(1).as_deref() == Some("xsd") {
+        return xsd_cmd::run();
     }
     // `cache` -> see and drop the stage outputs kept for reuse. Separate from
     // `checkpoint` because the two hold different things: a cached output can

--- a/crates/duckle-runner/src/xsd_cmd.rs
+++ b/crates/duckle-runner/src/xsd_cmd.rs
@@ -1,0 +1,209 @@
+//! `duckle-runner xsd` - inspect and explicitly accept parser contracts (#315).
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+const USAGE: &str = "\
+duckle-runner xsd <list|accept> [flags]
+
+Inspect or explicitly accept resolved XSD parser contracts.
+
+  list                         show accepted contracts
+  accept --uri URI --fingerprint SHA256
+                               accept exactly this observed contract
+
+  --workspace DIR              workspace (default: .)
+  --reason TEXT                why the contract was accepted
+  --json                       machine-readable output
+
+`accept` records the actor, time, old and new fingerprints, and reason in the
+workspace audit log. The fingerprint must be the exact SHA-256 reported by the
+failed run; acceptance never happens implicitly during execution.
+";
+
+struct Args {
+    verb: String,
+    workspace: PathBuf,
+    uri: Option<String>,
+    fingerprint: Option<String>,
+    reason: Option<String>,
+    json: bool,
+}
+
+fn next_value(
+    it: &mut impl Iterator<Item = String>,
+    name: &str,
+) -> Result<String, String> {
+    it.next().ok_or_else(|| format!("{name} needs a value"))
+}
+
+fn parse(argv: impl Iterator<Item = String>) -> Result<Args, String> {
+    let mut args = Args {
+        verb: String::new(),
+        workspace: PathBuf::from("."),
+        uri: None,
+        fingerprint: None,
+        reason: None,
+        json: false,
+    };
+    let mut it = argv;
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--workspace" => args.workspace = next_value(&mut it, "--workspace")?.into(),
+            "--uri" => args.uri = Some(next_value(&mut it, "--uri")?),
+            "--fingerprint" => args.fingerprint = Some(next_value(&mut it, "--fingerprint")?),
+            "--reason" => args.reason = Some(next_value(&mut it, "--reason")?),
+            "--json" => args.json = true,
+            "-h" | "--help" => return Err(String::new()),
+            other if other.starts_with('-') => return Err(format!("unknown flag {other}")),
+            other if args.verb.is_empty() => args.verb = other.to_string(),
+            other => return Err(format!("unexpected argument {other}")),
+        }
+    }
+    Ok(args)
+}
+
+fn valid_fingerprint(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+pub fn run() -> ExitCode {
+    let args = match parse(std::env::args().skip(2)) {
+        Ok(args) => args,
+        Err(e) if e.is_empty() => {
+            println!("{USAGE}");
+            return ExitCode::from(0);
+        }
+        Err(e) => {
+            eprintln!("duckle-runner xsd: {e}\n\n{USAGE}");
+            return ExitCode::from(2);
+        }
+    };
+    let path = duckle_duckdb_engine::xsd_contract::path(&args.workspace);
+    match args.verb.as_str() {
+        "list" => match duckle_duckdb_engine::xsd_contract::list(&path) {
+            Ok(entries) => {
+                if args.json {
+                    let rows: Vec<_> = entries
+                        .iter()
+                        .map(|(uri, fingerprint)| {
+                            serde_json::json!({
+                                "uri": uri,
+                                "fingerprint": fingerprint
+                            })
+                        })
+                        .collect();
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&rows).unwrap_or_default()
+                    );
+                } else if entries.is_empty() {
+                    println!("no accepted XSD contracts under {}", path.display());
+                } else {
+                    for (uri, fingerprint) in entries {
+                        println!("{uri} {fingerprint}");
+                    }
+                }
+                ExitCode::from(0)
+            }
+            Err(e) => {
+                eprintln!("duckle-runner xsd list: {e}");
+                ExitCode::from(2)
+            }
+        },
+        "accept" => {
+            let Some(uri) = args
+                .uri
+                .as_deref()
+                .filter(|v| !v.is_empty() && !v.chars().any(char::is_whitespace))
+            else {
+                eprintln!(
+                    "duckle-runner xsd accept: --uri is required and may not contain whitespace"
+                );
+                return ExitCode::from(2);
+            };
+            let Some(fingerprint) = args.fingerprint.as_deref().filter(|v| valid_fingerprint(v))
+            else {
+                eprintln!("duckle-runner xsd accept: --fingerprint must be a 64-character SHA-256 hex digest");
+                return ExitCode::from(2);
+            };
+            let reason = args.reason.as_deref().unwrap_or("no reason supplied");
+            if reason.bytes().any(|b| b == b'\r' || b == b'\n') {
+                eprintln!("duckle-runner xsd accept: --reason may not contain newlines");
+                return ExitCode::from(2);
+            }
+            let previous = match duckle_duckdb_engine::xsd_contract::accept(&path, uri, fingerprint)
+            {
+                Ok(previous) => previous,
+                Err(e) => {
+                    eprintln!("duckle-runner xsd accept: {e}");
+                    return ExitCode::from(2);
+                }
+            };
+            duckle_duckdb_engine::audit::note(
+                &args.workspace,
+                "xsd.contract.accept",
+                uri,
+                Some(format!(
+                    "{} -> {}; reason: {}",
+                    previous.as_deref().unwrap_or("none"),
+                    fingerprint,
+                    reason
+                )),
+            );
+            if args.json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "uri": uri,
+                        "previous": previous,
+                        "accepted": fingerprint,
+                        "reason": reason
+                    }))
+                    .unwrap_or_default()
+                );
+            } else {
+                println!("{uri}: accepted {fingerprint}");
+                println!(
+                    "Recorded the acceptance in {}",
+                    duckle_duckdb_engine::audit::audit_path(&args.workspace).display()
+                );
+            }
+            ExitCode::from(0)
+        }
+        _ => {
+            eprintln!("{USAGE}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprints_are_exact_sha256_values() {
+        assert!(valid_fingerprint(&"a".repeat(64)));
+        assert!(!valid_fingerprint("short"));
+        assert!(!valid_fingerprint(&"g".repeat(64)));
+    }
+
+    #[test]
+    fn flags_can_follow_the_verb_in_any_order() {
+        let args = parse(
+            [
+                "accept",
+                "--fingerprint",
+                &"a".repeat(64),
+                "--uri",
+                "schema.xsd",
+            ]
+            .into_iter()
+            .map(String::from),
+        )
+        .unwrap();
+        assert_eq!(args.verb, "accept");
+        assert_eq!(args.uri.as_deref(), Some("schema.xsd"));
+    }
+}

--- a/frontend/src/workflow-ui/fields/manifest-synth.ts
+++ b/frontend/src/workflow-ui/fields/manifest-synth.ts
@@ -2025,7 +2025,7 @@ function fileFormatSection(comp: ComponentDef): FormSection[] {
                             { label: 'Fail the run', value: 'fail' },
                             { label: 'Ignore', value: 'allow' },
                         ],
-                        description: 'The whole resolved schema set, including anything it imports, is remembered the first time it is read. If it later changes, the columns this feed is parsed into may change with it. Warn accepts the new set and says so once. Fail refuses the run until you accept the change by deleting the line from .duckle/xsd_contracts. Ignore does not look.',
+                        description: 'The whole resolved schema set, including anything it imports, is remembered the first time it is read. If it later changes, the columns this feed is parsed into may change with it. Warn accepts the new set and says so once. Fail refuses the run until you accept it with duckle-runner xsd accept. Ignore does not look.',
                     },
                 ],
             });


### PR DESCRIPTION
Fixes #315

## Summary
- add `duckle-runner xsd list` to inspect accepted XSD contract fingerprints
- add `duckle-runner xsd accept` requiring an exact SHA-256 and recording a reason
- record actor, timestamp, previous fingerprint, and accepted fingerprint in the existing audit log
- share the contract-store implementation between the connector and CLI
- update the CLI/UI documentation so fail-mode no longer requires hand-editing `.duckle/xsd_contracts`

## Verification
- `cargo test -p duckle-duckdb-engine xsd_contract --lib`
- `cargo check -p duckle-runner`

The runner test binary cannot be linked in this environment because the system ODBC static library is unavailable; compile checking succeeds.